### PR TITLE
Fix eslint setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -131,6 +131,7 @@
     "no-useless-escape": "off",
     "no-var": "error",
     "nonblock-statement-body-position": ["error", "below"],
+    "object-curly-spacing": ["off"],
     "padded-blocks": ["error", "never"],
     "prefer-arrow-callback": "error",
     "prefer-const": ["error", {

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docker_data/
 docs/reference/
 node_modules/
 npm-debug.log
+.vscode/

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2472,7 +2472,8 @@ class RPC extends RPCBase {
 
   async requestMissingBlocks(args, help) {
     if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'requestmissingblocks  ( "jsonrequestobject" )');
+      throw new RPCError(errs.MISC_ERROR,
+        'requestmissingblocks  ( "jsonrequestobject" )');
 
     const valid = new Validator(args);
     const knownHashes = valid.array(0);

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -325,7 +325,6 @@ class Account extends bio.Struct {
     return this.createKey(1);
   }
 
-
   /**
    * Get a specific address (does not increment depth).
    * @param {Number} index

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,6 +176,814 @@
         "nan": "^2.13.1"
       }
     },
+    "bslint": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/bslint/-/bslint-5.15.3.tgz",
+      "integrity": "sha512-isL4eFD0hXqmqFEVxVVp2X2cfPnPQikSO/l4/nc7jWdA144qKHYX+brxCvlz+vXuUPjQMVmWppqcHmZ4Yfsiig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "*",
+        "@babel/generator": "*",
+        "@babel/helper-function-name": "*",
+        "@babel/helper-get-function-arity": "*",
+        "@babel/helper-split-export-declaration": "*",
+        "@babel/highlight": "*",
+        "@babel/parser": "*",
+        "@babel/template": "*",
+        "@babel/traverse": "*",
+        "@babel/types": "*",
+        "acorn": "*",
+        "acorn-jsx": "*",
+        "ajv": "*",
+        "ansi-escapes": "*",
+        "ansi-regex": "*",
+        "ansi-styles": "*",
+        "argparse": "*",
+        "astral-regex": "*",
+        "babel-eslint": "*",
+        "balanced-match": "*",
+        "brace-expansion": "*",
+        "callsites": "*",
+        "chalk": "*",
+        "chardet": "*",
+        "cli-cursor": "*",
+        "cli-width": "*",
+        "color-convert": "*",
+        "color-name": "*",
+        "concat-map": "*",
+        "cross-spawn": "*",
+        "debug": "*",
+        "deep-is": "*",
+        "doctrine": "*",
+        "emoji-regex": "*",
+        "escape-string-regexp": "*",
+        "eslint": "*",
+        "eslint-scope": "*",
+        "eslint-utils": "*",
+        "eslint-visitor-keys": "*",
+        "espree": "*",
+        "esprima": "*",
+        "esquery": "*",
+        "esrecurse": "*",
+        "estraverse": "*",
+        "esutils": "*",
+        "external-editor": "*",
+        "fast-deep-equal": "*",
+        "fast-json-stable-stringify": "*",
+        "fast-levenshtein": "*",
+        "figures": "*",
+        "file-entry-cache": "*",
+        "flat-cache": "*",
+        "flatted": "*",
+        "fs.realpath": "*",
+        "functional-red-black-tree": "*",
+        "glob": "*",
+        "globals": "*",
+        "has-flag": "*",
+        "iconv-lite": "*",
+        "ignore": "*",
+        "import-fresh": "*",
+        "imurmurhash": "*",
+        "inflight": "*",
+        "inherits": "*",
+        "inquirer": "*",
+        "is-fullwidth-code-point": "*",
+        "is-promise": "*",
+        "isexe": "*",
+        "js-tokens": "*",
+        "js-yaml": "*",
+        "jsesc": "*",
+        "json-schema-traverse": "*",
+        "json-stable-stringify-without-jsonify": "*",
+        "levn": "*",
+        "lodash": "*",
+        "mimic-fn": "*",
+        "minimatch": "*",
+        "minimist": "*",
+        "mkdirp": "*",
+        "ms": "*",
+        "mute-stream": "*",
+        "natural-compare": "*",
+        "nice-try": "*",
+        "once": "*",
+        "onetime": "*",
+        "optionator": "*",
+        "os-tmpdir": "*",
+        "parent-module": "*",
+        "path-is-absolute": "*",
+        "path-is-inside": "*",
+        "path-key": "*",
+        "prelude-ls": "*",
+        "progress": "*",
+        "punycode": "*",
+        "regexpp": "*",
+        "resolve-from": "*",
+        "restore-cursor": "*",
+        "rimraf": "*",
+        "run-async": "*",
+        "rxjs": "*",
+        "safer-buffer": "*",
+        "semver": "*",
+        "shebang-command": "*",
+        "shebang-regex": "*",
+        "signal-exit": "*",
+        "slice-ansi": "*",
+        "source-map": "*",
+        "sprintf-js": "*",
+        "string-width": "*",
+        "strip-ansi": "*",
+        "strip-json-comments": "*",
+        "supports-color": "*",
+        "table": "*",
+        "text-table": "*",
+        "through": "*",
+        "tmp": "*",
+        "to-fast-properties": "*",
+        "trim-right": "*",
+        "tslib": "*",
+        "type-check": "*",
+        "uri-js": "*",
+        "which": "*",
+        "wordwrap": "*",
+        "wrappy": "*",
+        "write": "*"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/generator": {
+          "version": "7.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "acorn": {
+          "version": "6.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.10.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dev": true
+        },
+        "astral-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-eslint": {
+          "version": "10.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "callsites": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "eslint": {
+          "version": "5.15.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "eslint-scope": "*"
+          },
+          "dependencies": {
+            "eslint-scope": {
+              "version": "4.0.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "eslint-utils": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "espree": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "external-editor": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "flatted": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "globals": {
+          "version": "11.11.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "inquirer": {
+          "version": "6.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "*",
+            "strip-ansi": "*"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true,
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "parent-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rxjs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "table": {
+          "version": "5.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "*",
+            "string-width": "*",
+            "strip-ansi": "*"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "bsock": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "urkel": "~0.6.3"
   },
   "devDependencies": {
-    "bmocha": "^2.1.0"
+    "bmocha": "^2.1.0",
+    "bslint": "^5.15.3"
   },
   "main": "./lib/hsd.js",
   "bin": {

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -105,7 +105,7 @@ describe('Wallet', function() {
     const [key1, key2, key3] = await Promise.all([
       wallet.getReceive(accountIndex, 1),
       wallet.getReceive(accountIndex, 2),
-      wallet.getChange(accountIndex, 1),
+      wallet.getChange(accountIndex, 1)
     ]);
 
     assert(key1.getAddress().equals(expectedKey1.getAddress()));


### PR DESCRIPTION
1. Add bslint as a dev dependency
2. Explicitly allow any bracket spacing style (because different ones are used in the upstream code)
3. Fix linting errors introduced in in our fork.

@rsolari For the VSCode ESLint plugin you need to set the path in `hsd/.vscode/settings.json` (which I've gitignored here)
```JSON
{
    "eslint.nodePath": "node_modules/bslint",
}
```