### PR TITLE
wallet: add rpc endpoints to deal with raw hex payloads

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -237,6 +237,7 @@ class RPC extends RPCBase {
     this.add('getnames', this.getNames);
     this.add('getnameinfo', this.getNameInfo);
     this.add('getnameresource', this.getNameResource);
+    this.add('getnamerawresource', this.getNameRawResource);
     this.add('getnameproof', this.getNameProof);
     this.add('getnamebyhash', this.getNameByHash);
     this.add('grindname', this.grindName);
@@ -2373,6 +2374,25 @@ class RPC extends RPCBase {
     } catch (e) {
       return {};
     }
+  }
+
+  async getNameRawResource(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'getnamerawresource "name"');
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const nameHash = rules.hashName(name);
+    const ns = await this.chain.db.getNameState(nameHash);
+
+    if (!ns || ns.data.length === 0)
+      return null;
+
+    return ns.data.toString('hex');
   }
 
   async getNameProof(args, help) {

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -182,6 +182,7 @@ class RPC extends RPCBase {
     this.add('sendreveal', this.sendReveal);
     this.add('sendredeem', this.sendRedeem);
     this.add('sendupdate', this.sendUpdate);
+    this.add('sendrawupdate', this.sendRawUpdate);
     this.add('sendrenewal', this.sendRenewal);
     this.add('sendtransfer', this.sendTransfer);
     this.add('sendcancel', this.sendCancel);
@@ -193,6 +194,7 @@ class RPC extends RPCBase {
     this.add('createreveal', this.createReveal);
     this.add('createredeem', this.createRedeem);
     this.add('createupdate', this.createUpdate);
+    this.add('createrawupdate', this.createUpdate);
     this.add('createrenewal', this.createRenewal);
     this.add('createtransfer', this.createTransfer);
     this.add('createcancel', this.createCancel);
@@ -2146,10 +2148,31 @@ class RPC extends RPCBase {
     return tx.getJSON(this.network);
   }
 
+  async sendRawUpdate(args, help) {
+    const opts = this._validateRawUpdate(args, help, 'sendrawupdate');
+    const wallet = this.wallet;
+    const tx = await wallet.sendRawUpdate(opts.name, opts.resourceHex, {
+      account: opts.account
+    });
+
+    return tx.getJSON(this.network);
+  }
+
   async createUpdate(args, help) {
     const opts = this._validateUpdate(args, help, 'createupdate');
     const wallet = this.wallet;
     const mtx = await wallet.createUpdate(opts.name, opts.resource, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  async createRawUpdate(args, help) {
+    const opts = this._validateRawUpdate(args, help, 'createrawupdate');
+    const wallet = this.wallet;
+    const mtx = await wallet.createRawUpdate(opts.name, opts.resourceHex, {
       paths: true,
       account: opts.account
     });
@@ -2178,6 +2201,29 @@ class RPC extends RPCBase {
     return {
       name,
       resource,
+      account
+    };
+  }
+
+  _validateRawUpdate(args, help, method) {
+    if (help || args.length < 2 || args.length > 3)
+      throw new RPCError(errs.MISC_ERROR, method
+        + '"name" "resourceHex" ( "account" )');
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const resourceHex = valid.str(1);
+    const account = valid.str(2);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    if (!resourceHex)
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid hex string.');
+
+    return {
+      name,
+      resourceHex,
       account
     };
   }

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -173,6 +173,7 @@ class RPC extends RPCBase {
     this.add('getauctioninfo', this.getAuctionInfo);
     this.add('getnameinfo', this.getNameInfo);
     this.add('getnameresource', this.getNameResource);
+    this.add('getnamerawresource', this.getNameRawResource);
     this.add('getnamebyhash', this.getNameByHash);
     this.add('createclaim', this.createClaim);
     this.add('sendfakeclaim', this.sendFakeClaim);
@@ -1865,6 +1866,25 @@ class RPC extends RPCBase {
     } catch (e) {
       return {};
     }
+  }
+
+  async getNameRawResource(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'getnamerawresource "name"');
+
+    const wallet = this.wallet;
+    const valid = new Validator(args);
+    const name = valid.str(0);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const ns = await wallet.getNameStateByName(name);
+
+    if (!ns || ns.data.length === 0)
+      return null;
+
+    return ns.data.toString('hex');
   }
 
   async getNameByHash(args, help) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2371,6 +2371,84 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Make a raw register MTX.
+   * @private
+   * @param {String} name
+   * @param {String?} resourceHex
+   * @returns {MTX}
+   */
+
+  async _makeRawRegister(name, resourceHex) {
+    assert(typeof name === 'string');
+    assert(!resourceHex || typeof resourceHex === 'string');
+
+    if (!rules.verifyName(name))
+      throw new Error(`Invalid name: "${name}".`);
+
+    const rawName = Buffer.from(name, 'ascii');
+    const nameHash = rules.hashName(rawName);
+    const ns = await this.getNameState(nameHash);
+    const height = this.wdb.height + 1;
+    const network = this.network;
+
+    if (!ns)
+      throw new Error(`Auction not found: "${name}".`);
+
+    const {hash, index} = ns.owner;
+    const coin = await this.getCoin(hash, index);
+
+    if (!coin)
+      throw new Error(`Wallet did not win the auction: "${name}".`);
+
+    if (ns.isExpired(height, network))
+      throw new Error(`Name has expired: "${name}"!`);
+
+    // Is local?
+    if (coin.height < ns.height)
+      throw new Error(`Wallet did not win the auction: "${name}".`);
+
+    if (!coin.covenant.isReveal() && !coin.covenant.isClaim())
+      throw new Error(`Name must be in REVEAL or CLAIM state: "${name}".`);
+
+    if (coin.covenant.isClaim()) {
+      if (height < coin.height + network.coinbaseMaturity)
+        throw new Error(`Claim is not yet mature: "${name}".`);
+    }
+
+    const state = ns.state(height, network);
+
+    if (state !== states.CLOSED)
+      throw new Error(`Auction is not yet closed: "${name}".`);
+
+    const output = new Output();
+    output.address = coin.address;
+    output.value = ns.value;
+
+    output.covenant.type = types.REGISTER;
+    output.covenant.pushHash(nameHash);
+    output.covenant.pushU32(ns.height);
+
+    if (resourceHex) {
+      const raw = Buffer.from(resourceHex, 'hex');
+
+      if (raw.length > rules.MAX_RESOURCE_SIZE)
+        throw new Error(`Resource exceeds maximum size: "${name}".`);
+
+      output.covenant.push(raw);
+    } else {
+      output.covenant.push(EMPTY);
+    }
+
+    output.covenant.pushHash(await this.wdb.getRenewalBlock());
+
+    const mtx = new MTX();
+    mtx.addOutpoint(ns.owner);
+    mtx.outputs.push(output);
+
+    return mtx;
+  }
+
+  /**
    * Make an update MTX.
    * @param {String} name
    * @param {Resource} resource
@@ -2442,6 +2520,77 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Make a raw update MTX.
+   * @param {String} name
+   * @param {String} resourceHex
+   * @returns {MTX}
+   */
+
+  async makeRawUpdate(name, resourceHex) {
+    assert(typeof name === 'string');
+    assert(typeof resourceHex === 'string');
+
+    if (!rules.verifyName(name))
+      throw new Error(`Invalid name: "${name}".`);
+
+    const rawName = Buffer.from(name, 'ascii');
+    const nameHash = rules.hashName(rawName);
+    const ns = await this.getNameState(nameHash);
+    const height = this.wdb.height + 1;
+    const network = this.network;
+
+    if (!ns)
+      throw new Error(`Auction not found: "${name}".`);
+
+    const {hash, index} = ns.owner;
+    const coin = await this.getCoin(hash, index);
+
+    if (!coin)
+      throw new Error(`Wallet does not own: "${name}".`);
+
+    if (coin.covenant.isReveal() || coin.covenant.isClaim())
+      return this._makeRawRegister(name, resourceHex);
+
+    if (ns.isExpired(height, network))
+      throw new Error(`Name has expired: "${name}"!`);
+
+    // Is local?
+    if (coin.height < ns.height)
+      throw new Error(`Wallet does not own: "${name}".`);
+
+    const state = ns.state(height, network);
+
+    if (state !== states.CLOSED)
+      throw new Error(`Auction is not yet closed: "${name}".`);
+
+    if (!coin.covenant.isRegister()
+        && !coin.covenant.isUpdate()
+        && !coin.covenant.isRenew()
+        && !coin.covenant.isFinalize()) {
+      throw new Error(`Name must be registered: "${name}".`);
+    }
+
+    const raw = Buffer.from(resourceHex, 'hex');
+
+    if (raw.length > rules.MAX_RESOURCE_SIZE)
+      throw new Error(`Resource exceeds maximum size: "${name}".`);
+
+    const output = new Output();
+    output.address = coin.address;
+    output.value = coin.value;
+    output.covenant.type = types.UPDATE;
+    output.covenant.pushHash(nameHash);
+    output.covenant.pushU32(ns.height);
+    output.covenant.push(raw);
+
+    const mtx = new MTX();
+    mtx.addOutpoint(ns.owner);
+    mtx.outputs.push(output);
+
+    return mtx;
+  }
+
+  /**
    * Create and finalize an update
    * MTX without a lock.
    * @param {String} name
@@ -2452,6 +2601,21 @@ class Wallet extends EventEmitter {
 
   async _createUpdate(name, resource, options) {
     const mtx = await this.makeUpdate(name, resource);
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Create and finalize a raw update
+   * MTX without a lock.
+   * @param {String} name
+   * @param {String} resourceHex
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createRawUpdate(name, resourceHex, options) {
+    const mtx = await this.makeRawUpdate(name, resourceHex);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -2475,6 +2639,24 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Create and finalize a raw update
+   * MTX with a lock.
+   * @param {String} name
+   * @param {String} resourceHex
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createRawUpdate(name, resourceHex, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createRawUpdate(name, resourceHex, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
    * Create and send an update
    * MTX without a lock.
    * @param {String} name
@@ -2485,6 +2667,20 @@ class Wallet extends EventEmitter {
   async _sendUpdate(name, resource, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createUpdate(name, resource, options);
+    return this.sendMTX(mtx, passphrase);
+  }
+
+  /**
+   * Create and send a raw update
+   * MTX without a lock.
+   * @param {String} name
+   * @param {String} resourceHex
+   * @param {Object} options
+   */
+
+  async _sendRawUpdate(name, resourceHex, options) {
+    const passphrase = options ? options.passphrase : null;
+    const mtx = await this._createRawUpdate(name, resourceHex, options);
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2500,6 +2696,23 @@ class Wallet extends EventEmitter {
     const unlock = await this.fundLock.lock();
     try {
       return await this._sendUpdate(name, resource, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a raw update
+   * MTX with a lock.
+   * @param {String} name
+   * @param {String} resourceHex
+   * @param {Object} options
+   */
+
+  async sendRawUpdate(name, resourceHex, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._sendRawUpdate(name, resourceHex, options);
     } finally {
       unlock();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "namebase-hsd",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namebase-hsd",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "description": "Cryptocurrency bike-shed",
   "license": "MIT",


### PR DESCRIPTION
This change was necessary to allow our users to have full control over the data stored at their name. Can make PR back to main repo after some user testing, but we need this feature now in to finish the other PR

1. Adds a `sendrawupdate` RPC call to the wallet to set raw hex at a name
2. Adds a `getnamerawresource` RPC call to the wallet AND node to get the raw hex at a name

Note: 99% of this code is copy pasted. I thought it was better to duplicate the `sendupdate`/`getnameresource` code rather than abstract out the commonalities to make future upstream changes easier to merge.