### PR TITLE
wallet: expose a coin distribution endpoint for utxo summary statistics

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -646,6 +646,41 @@ class HTTP extends Server {
       res.json(200, result);
     });
 
+    // Wallet UTXO summary statistics
+    // Counts the total HNS within each range of output values for all UTXOs
+    this.get('/wallet/:id/coin-distribution', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const acct = valid.str('account');
+      const bucketExponent = valid.float('bucketExponent');
+      enforce(bucketExponent != null, 'Bucket exponent is required.');
+
+      const coins = await req.wallet.getCoins(acct);
+      const coinsByValue = coins.sort((a, b) => a.value - b.value);
+
+      const buckets = [makeDistributionBucket(0, 100000)];
+      for (const coin of coinsByValue) {
+        // First, figure out which bucket this coin belongs in
+        let currentMax = buckets[buckets.length - 1].maxValue;
+        while (coin.value >= currentMax) {
+          const nextMax = Math.floor(currentMax * bucketExponent);
+          const nextBucket = makeDistributionBucket(currentMax, nextMax);
+          buckets.push(nextBucket);
+          currentMax = nextMax;
+        }
+        const currentBucket = buckets[buckets.length - 1];
+
+        // Next, add this coin's details to this bucket's statistics
+        const covenantType = rules.typesByVal[coin.covenant.type];
+        if (!currentBucket.counts.hasOwnProperty(covenantType)) {
+          currentBucket.counts[covenantType] = 0;
+        }
+        currentBucket.totalValue += coin.value;
+        currentBucket.counts[covenantType] += 1;
+      }
+
+      res.json(200, { distributions: [buckets] });
+    });
+
     // Locked coins
     this.get('/wallet/:id/locked', async (req, res) => {
       const locked = req.wallet.getLocked();
@@ -1708,6 +1743,10 @@ function enforce(value, msg) {
     err.statusCode = 400;
     throw err;
   }
+}
+
+function makeDistributionBucket(minValue, maxValue) {
+  return { minValue, maxValue, counts: {}, totalValue: 0 };
 }
 
 /*


### PR DESCRIPTION
Usage:
```bash
curl http://x:apikey@localhost:14039/wallet/:wallet/coin-distribution\?bucketExponent\=10
```

Output:
```json
{
  "distributions": [
    [
      {
        "minValue": 0,
        "maxValue": 100000,
        "counts": { "OPEN": 9, "REGISTER": 1, "RENEW": 1 },
        "totalValue": 0
      },
      {
        "minValue": 100000,
        "maxValue": 1000000,
        "counts": { "NONE": 4 },
        "totalValue": 3975060
      },
      {
        "minValue": 1000000,
        "maxValue": 10000000,
        "counts": { "REDEEM": 5, "REGISTER": 2, "NONE": 2 },
        "totalValue": 15990580
      },
      {
        "minValue": 10000000,
        "maxValue": 100000000,
        "counts": {},
        "totalValue": 0
      },
      {
        "minValue": 100000000,
        "maxValue": 1000000000,
        "counts": { "NONE": 1 },
        "totalValue": 100000000
      },
      {
        "minValue": 1000000000,
        "maxValue": 10000000000,
        "counts": { "NONE": 1831 },
        "totalValue": 3661854639960
      }
    ]
  ]
}
```