### PR TITLE
'sweepdust' coin selection

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1638,7 +1638,7 @@ class CoinSelector {
     if (this.tx.view.hasEntry(coin))
       return false;
 
-    if (coin.covenant.isNonspendable())
+    if (coin.covenant.isNonspendable() || (coin.covenant.isOpen() && this.selection === 'sweepdust'))
       return false;
 
     if (this.height === -1)

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1638,7 +1638,10 @@ class CoinSelector {
     if (this.tx.view.hasEntry(coin))
       return false;
 
-    if (coin.covenant.isNonspendable() || (coin.covenant.isOpen() && this.selection === 'sweepdust'))
+    if (coin.covenant.isNonspendable())
+      return false;
+
+    if (this.selection === 'sweepdust' && coin.value === 0)
       return false;
 
     if (this.height === -1)

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1598,6 +1598,9 @@ class CoinSelector {
       case 'value':
         this.coins.sort(sortValue);
         break;
+      case 'sweepdust':
+        this.coins.sort(reversed(sortValue))
+        break;
       default:
         throw new FundingError(`Bad selection type: ${this.selection}.`);
     }
@@ -1898,6 +1901,7 @@ function sortRandom(a, b) {
   return Math.random() > 0.5 ? 1 : -1;
 }
 
+// sorts from large to small
 function sortValue(a, b) {
   if (a.height === -1 && b.height !== -1)
     return 1;
@@ -1906,6 +1910,10 @@ function sortValue(a, b) {
     return -1;
 
   return b.value - a.value;
+}
+
+function reversed(sortFunc) {
+  return (a, b) => sortFunc(b, a)
 }
 
 function sortInputs(a, b) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1215,6 +1215,7 @@ class Wallet extends EventEmitter {
   /**
    * Fill a transaction with inputs without a lock.
    * @private
+   * @param {MTX} mtx - The mutable transaction to fill
    * @see MTX#selectCoins
    * @see MTX#fill
    */


### PR DESCRIPTION
Ok, turns out I think this is actually kind of easy once you step back, and I was making it way harder than I needed to.

Turns out there was already a way to sort by value (big to small) in `MTX#CoinSelector`, so I just added a new selector that sorts by reverse value (small to big). It should work with the existing send endpoint. Then, with the `/wallet/:id/coin-distribution` endpoint that @turbomaze already added we can select an appropriate "value" parameter. With `"depth": 1`, we can run the process multiple times in the same block and it won't re-use the new outputs.

If you do a request like:
```
POST http://x:api-key@hsdnode:14039/wallet/hot/send 
{
  "outputs":[
    {"address":"some-destination-address", "value": ... }
  ],
 selection: 'sweepdust',
 depth: 1,
}
```

