### PR TITLE
Don't recurse if the question name matches the resolver suffix.

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -172,6 +172,10 @@ class RootServer extends DNSServer {
 
     if (options.suffix != null) {
       this.suffix = options.suffix;
+      const cleanedZone = this.suffix.split('.').filter(Boolean).join('\\.');
+      const boundary = '(\\.|\\b)';
+      const suffixGroup = `${boundary}${cleanedZone}${boundary}`;
+      this.suffixRegex = new RegExp(`(${suffixGroup})+$`, 'g');
     }
 
     if (options.soaRewrite != null) {
@@ -425,17 +429,16 @@ class RootServer extends DNSServer {
     }
 
     try {
-      const name = req.question[0].name;
-      let changed;
-
       // If domain is in the form *.{SUFFIX}, query only the {SUFFIX} subdomain
-      [req, changed] = removeSuffix(req, this.suffix);
+      const originalName = getName(req);
+      req = removeSuffix(req, this.suffixRegex);
+      const newName = getName(req);
 
       res = await this.answer(req, rinfo);
 
       // Change query back to original name
-      if (changed) {
-        [req, res] = addSuffix(req, res, name);
+      if (originalName !== newName) {
+        [req, res] = restoreName(req, res, originalName);
       }
     } catch (e) {
       this.emit('error', e);
@@ -456,8 +459,6 @@ class RootServer extends DNSServer {
     }
 
     res = new Response(this, req, rinfo);
-    res.setReply(req);
-    res.ra = this.ra;
     this.emit('query', req, res, rinfo);
   }
 
@@ -717,6 +718,10 @@ class RecursiveServer extends DNSServer {
 
     if (options.suffix != null) {
       this.suffix = options.suffix;
+      const cleanedZone = this.suffix.split('.').filter(Boolean).join('\\.');
+      const boundary = '(\\.|\\b)';
+      const suffixGroup = `${boundary}${cleanedZone}${boundary}`;
+      this.suffixRegex = new RegExp(`(${suffixGroup})+$`, 'g');
     }
 
     if (options.soaRewrite != null) {
@@ -783,22 +788,33 @@ class RecursiveServer extends DNSServer {
       return;
     }
 
-    const name = req.question[0].name;
-
     // If domain in the form *.{SUFFIX}, query only the {SUFFIX} subdomain
-    let changed = false;
-    [req, changed] = removeSuffix(req, this.suffix);
+    const originalName = getName(req);
+    req = removeSuffix(req, this.suffixRegex);
+    const newName = getName(req);
+
     try {
       const type = req.question[0].type;
 
-      res = await this.answer(req, rinfo);
+      const isMaliciouslyRecursive = newName === '.' && originalName !== '.';
+      if (isMaliciouslyRecursive) {
+        // empty response; let the SOA get filled in later
+        res = new Response(this, req, rinfo);
+      } else {
+        res = await this.answer(req, rinfo);
+      }
 
       // Rewrite to {SUFFIX} SOA
       if (type === types.SOA && Boolean(this.soaRewrite)) {
         res.answer = [this.toSOADefault()];
       }
+
       // Send {SUFFIX} SOA if answer is empty
-      if (res.answer.length === 0 && Boolean(this.soaRewrite) && name !== '.') {
+      if (
+        res.answer.length === 0 &&
+        Boolean(this.soaRewrite) &&
+        originalName !== '.'
+      ) {
         res.authority = [this.toSOADefault()];
       }
     } catch (e) {
@@ -814,19 +830,19 @@ class RecursiveServer extends DNSServer {
     }
 
     // Change back to original name
-    if (changed)
-      [req, res] = addSuffix(req, res, name);
+    if (originalName !== newName) {
+      [req, res] = restoreName(req, res, originalName);
+    }
 
+    // Happy case
     if (res) {
       this.emit('query', req, res, rinfo);
       this.send(req, res, rinfo);
       return;
     }
 
+    // Note: assert(res); this code should never be executed
     res = new Response(this, req, rinfo);
-    res.setReply(req);
-    res.ra = this.ra;
-
     this.emit('query', req, res, rinfo);
   }
 
@@ -940,6 +956,9 @@ class Response extends Message {
     this._req = req;
     this._rinfo = rinfo;
     this._sent = false;
+
+    this.setReply(req);
+    this.ra = server.ra;
   }
 
   send() {
@@ -973,30 +992,34 @@ function toKey(name, type) {
   return key;
 }
 
-function removeSuffix(req, suffix) {
-  const name = req.question[0].name;
-  let changed = false;
-  if (suffix) {
-    const zonePattern = `.*\.${suffix.split('.').join('\.')}`;
-    const found = name.match(zonePattern);
-    if (found) {
-      let handshakeName = name.slice(0, -suffix.length);
-      if (handshakeName === '') {
-        handshakeName = '.';
-      }
-      req.question[0].name = handshakeName;
-      changed = true;
-    }
-  }
-  return [req, changed];
+function getName(req) {
+  return req.question[0].name;
 }
 
-function addSuffix(req, res, name) {
-  res.question[0].name = name;
-  if (res.answer.length !== 0) {
-    res.answer[0].name = name;
+function removeSuffix(req, regex) {
+  if (regex) {
+    const originalName = getName(req);
+    let handshakeName = originalName.replace(regex, '');
+    if (handshakeName === '') {
+      handshakeName = '.';
+    }
+
+    setNameField(req.question, handshakeName);
   }
+  return req;
+}
+
+function restoreName(req, res, originalName) {
+  setNameField(req.question, originalName);
+  setNameField(res.question, originalName);
+  setNameField(res.answer, originalName);
   return [req, res];
+}
+
+function setNameField(list, name) {
+  for (let i = 0; i < list.length; i++) {
+    list[i].name = name;
+  }
 }
 
 /*


### PR DESCRIPTION
## Before
If the deployed resolver had a resolver suffix of `a.b`, then querying `*(a.b.)+` could cause problems.

## After
Instead of replacing just the suffix, we replace all `${suffix}+$`. Then, in the case of a query that results in a recursive cycle, we don't bother generating an answer and just send an SOA. Another nameserver layer in front of the handshake resolver handles serving NS records for the zone, so only other question types will hit this empty response SOA.