### PR TITLE
Dump zone functionality

### DIFF
--- a/lib/node/dumpzone.js
+++ b/lib/node/dumpzone.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const bns = require('bns');
+const {types} = require('bns/lib/constants');
+const stream = require('stream');
+
+const NameState = require('../covenants/namestate');
+const {Resource} = require('../dns/resource');
+
+/**
+ * @typedef {import('../blockchain').Chain} Chain
+ */
+
+/**
+ * readableStream produces a newline-delimited list of all
+ * DNS records on a chain, except for RRSIG, as a utf8
+ * encoded string.
+ *
+ * @param {Chain} chain the chain to stream from
+ * @returns {stream.Readable} a readable stream of DNS records
+ */
+function readableStream(chain) {
+  const iter = chain.db.tree.iterator(true);
+
+  async function* gen() {
+    while (await iter.next()) {
+      /** @type {NameState} */
+      const ns = NameState.decode(iter.value);
+      if (ns.data.length <= 0)
+        continue;
+
+      /** @type {string} */
+      const fqdn = bns.util.fqdn(ns.name.toString('ascii'));
+
+      /** @type {Resource} */
+      const resource = Resource.decode(ns.data);
+      const zone = resource.toZone(fqdn);
+      for (const record of zone) {
+        if (record.type !== types.RRSIG && record.type !== types.TXT)
+          yield record.toString() + '\n';
+      }
+    }
+  }
+
+  return stream.Readable.from(gen(), {encoding: 'utf8'});
+}
+
+module.exports = {
+    readableStream: readableStream
+};

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -6,6 +6,10 @@
 
 'use strict';
 
+const constants = require('bns/lib/constants');
+const {types} = constants;
+const fs = require('fs');
+const bns = require('bns');
 const assert = require('bsert');
 const bweb = require('bweb');
 const {Lock} = require('bmutex');
@@ -247,6 +251,7 @@ class RPC extends RPCBase {
     this.add('validateresource', this.validateResource);
 
     this.add('resetrootcache', this.resetRootCache);
+    this.add('dumpzone', this.dumpzone);
 
     // Compat
     // this.add('getnameinfo', this.getNameInfo);
@@ -2575,6 +2580,68 @@ class RPC extends RPCBase {
     this.node.ns.resetCache();
 
     return null;
+  }
+
+ async dumpzone(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'dumpzone <filename>');
+
+    const valid = new Validator(args);
+    const filename = valid.str(0, null);
+    if (filename == null)
+      throw new RPCError(errs.MISC_ERROR, 'dumpzone <filename>');
+
+    const tmp = filename + '~';
+    this.logger.debug(`dumping root zone to file: ${filename}`);
+
+    let fd = null;
+    let fileErr = null;
+    fd = fs.createWriteStream(tmp, { flags: 'a+' });
+    fd.on('error', (err) => {
+      fd.end();
+      fd = null;
+      fileErr = err;
+    });
+
+    const tree = this.chain.db.tree;
+    const iter = tree.iterator(true);
+
+    let count = 0;
+    while ((await iter.next()) && (fd != null)) {
+      count++;
+      if (count % 10000 === 0)
+        this.logger.debug('dumpzone names processed: %d', count);
+
+      if (fd == null)
+        break;
+
+      const {value} = iter;
+      const ns = NameState.decode(value);
+
+      if (ns.data.length <= 0)
+        continue;
+
+      const fqdn = bns.util.fqdn(ns.name.toString('ascii'));
+      const resource = Resource.decode(ns.data);
+      const zone = resource.toZone(fqdn);
+      for (const record of zone) {
+        if (fd == null)
+          break;
+
+        if (record.type !== types.RRSIG)
+          fd.write(record.toString() + '\n');
+      }
+    }
+
+    if (fd == null)
+      return fileErr;
+
+    fd.end();
+    fs.renameSync(tmp, filename);
+
+    this.logger.debug('root zone dump complete. Total names: %d', count);
+
+    return filename;
   }
 
   /*

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -6,10 +6,7 @@
 
 'use strict';
 
-const constants = require('bns/lib/constants');
-const {types} = constants;
 const fs = require('fs');
-const bns = require('bns');
 const assert = require('bsert');
 const bweb = require('bweb');
 const {Lock} = require('bmutex');
@@ -46,6 +43,8 @@ const AirdropProof = require('../primitives/airdropproof');
 const {EXP} = consensus;
 const RPCBase = bweb.RPC;
 const RPCError = bweb.RPCError;
+const dumpzone = require('./dumpzone');
+const stream = require('stream');
 
 /*
  * Constants
@@ -2594,54 +2593,21 @@ class RPC extends RPCBase {
     const tmp = filename + '~';
     this.logger.debug(`dumping root zone to file: ${filename}`);
 
-    let fd = null;
-    let fileErr = null;
-    fd = fs.createWriteStream(tmp, { flags: 'a+' });
-    fd.on('error', (err) => {
-      fd.end();
-      fd = null;
-      fileErr = err;
+    return new Promise((resolve, reject) => {
+      stream.pipeline(
+        dumpzone.readableStream(this.chain),
+        fs.createWriteStream(tmp, { flags: 'a+' }),
+        (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            fs.renameSync(tmp, filename);
+            this.logger.debug('root zone dump complete');
+            resolve(filename);
+          }
+        }
+      );
     });
-
-    const tree = this.chain.db.tree;
-    const iter = tree.iterator(true);
-
-    let count = 0;
-    while ((await iter.next()) && (fd != null)) {
-      count++;
-      if (count % 10000 === 0)
-        this.logger.debug('dumpzone names processed: %d', count);
-
-      if (fd == null)
-        break;
-
-      const {value} = iter;
-      const ns = NameState.decode(value);
-
-      if (ns.data.length <= 0)
-        continue;
-
-      const fqdn = bns.util.fqdn(ns.name.toString('ascii'));
-      const resource = Resource.decode(ns.data);
-      const zone = resource.toZone(fqdn);
-      for (const record of zone) {
-        if (fd == null)
-          break;
-
-        if (record.type !== types.RRSIG)
-          fd.write(record.toString() + '\n');
-      }
-    }
-
-    if (fd == null)
-      return fileErr;
-
-    fd.end();
-    fs.renameSync(tmp, filename);
-
-    this.logger.debug('root zone dump complete. Total names: %d', count);
-
-    return filename;
   }
 
   /*


### PR DESCRIPTION
Have refactored zippy's branch to use streams (because it will make uploading to S3 easier) and filtered out TXT records.

In progress:

- [ ] Load AWS credentials
- [ ] Configure destination bucket/key
- [ ] Stream to S3