### PR TITLE
Add GET /wallet/:id/ownsName/:name

### DIFF
--- a/lib/covenants/namestate.js
+++ b/lib/covenants/namestate.js
@@ -648,6 +648,12 @@ class NameState extends bio.Struct {
     return this;
   }
 
+  /**
+   * getJSON produces a representation of this object sutable for serialization
+   * @param {number} height the block height to serialize at
+   * @param {Network} network the network to serialize on
+   * @return {Object} an object suitable for JSON serialization
+   */
   getJSON(height, network) {
     let state = undefined;
     let stats = undefined;

--- a/lib/primitives/outpoint.js
+++ b/lib/primitives/outpoint.js
@@ -30,6 +30,7 @@ class Outpoint extends bio.Struct {
   constructor(hash, index) {
     super();
 
+    /** @type {Buffer} */
     this.hash = consensus.ZERO_HASH;
     this.index = 0xffffffff;
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -31,6 +31,12 @@ const common = require('./common');
 const Wallet = require('./wallet');
 
 /**
+ * @typedef {import('../protocol/network')} Network
+ * @typedef {import('./walletdb')} WalletDB
+ * @typedef {import('./rpc') RPC}
+ */
+
+/**
  * HTTP
  * @alias module:wallet.HTTP
  */
@@ -45,9 +51,12 @@ class HTTP extends Server {
   constructor(options) {
     super(new HTTPOptions(options));
 
+    /** @type {Network} */
     this.network = this.options.network;
     this.logger = this.options.logger.context('wallet-http');
+    /** @type {WalletDB} */
     this.wdb = this.options.node.wdb;
+    /** @type {RPC} */
     this.rpc = this.options.node.rpc;
 
     this.init();
@@ -936,7 +945,7 @@ class HTTP extends Server {
     });
 
     // Wallet Name State
-    this.get('/wallet/:id/ownsName/:name', async (req, res) => {
+    this.get('/wallet/:id/owns-name/:name', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
 
@@ -953,7 +962,7 @@ class HTTP extends Server {
         return res.json(404);
 
       const tx = await wallet.getTX(ns.owner.hash);
-      if(!tx)
+      if (!tx)
         return res.json(404);
 
       const details = await wallet.toDetails(tx);

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -935,6 +935,37 @@ class HTTP extends Server {
       return res.json(200, ns.getJSON(height, network));
     });
 
+    // Wallet Name State
+    this.get('/wallet/:id/ownsName/:name', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const name = valid.str('name');
+
+      assert(name, 'Must pass name.');
+      assert(rules.verifyName(name), 'Must pass valid name.');
+
+      const height = this.wdb.height;
+      const network = this.network;
+
+      /** @type {Wallet} */
+      const wallet = req.wallet;
+      const ns = await wallet.getNameStateByName(name);
+      if (!ns)
+        return res.json(404);
+
+      const tx = await wallet.getTX(ns.owner.hash);
+      if(!tx)
+        return res.json(404);
+
+      const details = await wallet.toDetails(tx);
+      const ownerOutput = details.outputs[ns.owner.index];
+
+      if(await wallet.hasAddress(ownerOutput.address)) {
+        return res.json(200, ns.getJSON(height, network));
+      }
+
+      return res.json(404, {success: true});
+    });
+
     // Wallet Auctions
     this.get('/wallet/:id/auction', async (req, res) => {
       const height = this.wdb.height;

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2915,8 +2915,8 @@ class TXDB {
 
   /**
    * Convert transaction to transaction details.
-   * @param {TXRecord[]} wtxs
-   * @returns {Promise}
+   * @param {TXRecord | TXRecord[]} wtxs
+   * @returns {Promise<Details | Details[]>}
    */
 
   async toDetails(wtxs) {
@@ -2941,7 +2941,7 @@ class TXDB {
    * Convert transaction to transaction details.
    * @private
    * @param {TXRecord} wtx
-   * @returns {Promise}
+   * @returns {Promise<Details>}
    */
 
   async _toDetails(wtx) {
@@ -3485,6 +3485,7 @@ class Details {
     }
 
     this.inputs = [];
+    /** @type {DetailsMember[]} */
     this.outputs = [];
 
     this.init();
@@ -3654,6 +3655,7 @@ class DetailsMember {
 
   constructor() {
     this.value = 0;
+    /** @type {string | null} */
     this.address = null;
     this.covenant = null;
     this.path = null;
@@ -3974,6 +3976,8 @@ class BidReveal extends bio.Struct {
     };
   }
 }
+
+TXDB.Details = Details;
 
 /*
  * Expose

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -43,6 +43,13 @@ const {BufferSet} = require('buffer-map');
 const Coin = require('../primitives/coin');
 const util = require('../utils/util');
 
+/**
+ * JSDoc types
+ *
+ * @typedef {import('../covenants/namestate')} NameState
+ * @typedef {import('../primitives/tx')} TX
+ */
+
 /*
  * Constants
  */
@@ -4568,7 +4575,7 @@ class Wallet extends EventEmitter {
   /**
    * Get a transaction from the wallet.
    * @param {Hash} hash
-   * @returns {Promise} - Returns {@link TX}.
+   * @returns {Promise<TX | null>} - Returns {@link TX}.
    */
 
   getTX(hash) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -44,10 +44,11 @@ const Coin = require('../primitives/coin');
 const util = require('../utils/util');
 
 /**
- * JSDoc types
+ * JSDoc imported types
  *
  * @typedef {import('../covenants/namestate')} NameState
  * @typedef {import('../primitives/tx')} TX
+ * @typedef {import('./txdb').Details} Details
  */
 
 /*
@@ -4544,7 +4545,7 @@ class Wallet extends EventEmitter {
   /**
    * Convert transaction to transaction details.
    * @param {TXRecord} wtx
-   * @returns {Promise} - Returns {@link Details}.
+   * @returns {Promise<Details>} - Returns {@link Details}.
    */
 
   toDetails(wtx) {


### PR DESCRIPTION
Have tested that it works on the receiving end on mainnet with `drugplug/`, a name that I withdrew to a local wallet from namebase. Still need to:

- [x] Verify that it deterministically selects an owner when both nodes have a FINALIZE
- [x] Figure out why it gives an empty response instead of a 404 (no repro, seems fine)