### PR TITLE
Ridvan sendmany http support

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1567,15 +1567,30 @@ class HTTP extends Server {
       if (sendTo.length === 0)
          throw new Error('parameter sendto is required and can not be empty!');
 
+      const cache = req.wallet.hsdTransferResults;
+      const results = [];
+
+      for (const {idempotencyKey} of sendTo) {
+        if (cache.has(idempotencyKey)) {
+          results.push(cache.get(idempotencyKey));
+        }
+      }
+
+      const filteredSendTo = sendTo.filter(element =>
+        !cache.has(element.idempotencyKey));
+
+      const addressToIdempotencyKeyMap = new Map();
       const uniq = new BufferSet();
 
-      const outputs = sendTo.map((element) => {
+      const outputs = filteredSendTo.map((element) => {
         const to = new Validator(element);
         const value   = to.u64('value');
         if (!value)
           throw new Error(`value: ${value} is invalid!`);
 
         const addr = parseAddress(to.str('address'), this.network);
+        addressToIdempotencyKeyMap.set(addr, element.idempotencyKey);
+
         const hash = addr.getHash();
 
         if (uniq.has(hash))
@@ -1598,7 +1613,25 @@ class HTTP extends Server {
       };
 
       const tx = await req.wallet.send(options, passphrase);
-      return res.json(200, tx.getJSON(this.network));
+      const txOutputsLen = tx.outputs.length;
+      // postprocess results
+      for (let i=0; i<txOutputsLen; i++) {
+         const output = tx.outputs[i];
+         if (addressToIdempotencyKeyMap.has(output.address)) {
+           results.push(
+             {
+              idempotencyKey: addressToIdempotencyKeyMap.get(output.address),
+              tx_hash: tx.hash,
+              output_index: i,
+              output: output
+            });
+            // populate cache as well
+            cache.put()
+
+         }
+      }
+
+      return res.json(200, {processedWithdrawals: results});
     });
   }
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1634,7 +1634,7 @@ class HTTP extends Server {
             const hsdTransfer =
             {
               idempotency_key: idempotencyKey,
-              tx_hash: tx.hash,
+              tx_hash: txJSON.hash,
               output_index: i,
               output: output
             };

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -11,9 +11,11 @@ const assert = require('bsert');
 const path = require('path');
 const {Server} = require('bweb');
 const Validator = require('bval');
+const {BufferSet} = require('buffer-map');
 const base58 = require('bcrypto/lib/encoding/base58');
 const MTX = require('../primitives/mtx');
 const Outpoint = require('../primitives/outpoint');
+const Output = require('../primitives/output');
 const sha256 = require('bcrypto/lib/sha256');
 const rules = require('../covenants/rules');
 const random = require('bcrypto/lib/random');
@@ -29,6 +31,7 @@ const {Resource} = require('../dns/resource');
 const common = require('./common');
 // eslint-disable-next-line no-unused-vars
 const Wallet = require('./wallet');
+const {EXP} = require('../protocol/consensus');
 
 /**
  * HTTP
@@ -1551,6 +1554,52 @@ class HTTP extends Server {
 
       return res.json(200, mtx.getJSON(this.network));
     });
+
+    // SendMany
+    this.post('/wallet/:id/sendmany', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const account = valid.str('account', 'default');
+      const sendTo = valid.array('sendto', []);
+      const minconf = valid.u32('minconf', 1);
+      const subtractFee = valid.bool('subtractfee', false);
+      const passphrase = valid.str('passphrase');
+
+      if (sendTo.length === 0)
+         throw new Error('parameter sendto is required and can not be empty!');
+
+      const uniq = new BufferSet();
+
+      const outputs = sendTo.map((element) => {
+        const to = new Validator(element);
+        const value   = to.u64('value');
+        if (!value)
+          throw new Error(`value: ${value} is invalid!`);
+
+        const addr = parseAddress(to.str('address'), this.network);
+        const hash = addr.getHash();
+
+        if (uniq.has(hash))
+            throw new Error('Invalid parameter!');
+
+          uniq.add(hash);
+
+          const output = new Output();
+          output.value = value;
+          output.address = addr;
+
+          return output;
+      });
+
+      const options = {
+        outputs: outputs,
+        subtractFee: subtractFee,
+        account: account,
+        depth: minconf
+      };
+
+      const tx = await req.wallet.send(options, passphrase);
+      return res.json(200, tx.getJSON(this.network));
+    });
   }
 
   /**
@@ -1985,6 +2034,14 @@ function isLockedCovenant(covenant) {
     rules.types.UPDATE
   ];
   return lockedTypes.includes(covenant.type);
+}
+
+function parseAddress(raw, network) {
+  try {
+    return Address.fromString(raw, network);
+  } catch (e) {
+    throw new Error(`${raw} Invalid address.`);
+  }
 }
 
 /*

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1569,14 +1569,14 @@ class HTTP extends Server {
       const cache = req.wallet.hsdTransferResults;
       const results = [];
 
-      for (const {idempotencyKey} of sendTo) {
+      for (const {idempotency_key: idempotencyKey} of sendTo) {
         if (idempotencyKey && cache.has(idempotencyKey)) {
           results.push(cache.get(idempotencyKey));
         }
       }
 
       const filteredSendTo = sendTo.filter(element =>
-        !cache.has(element.idempotencyKey));
+        !cache.has(element.idempotency_key));
 
       const addressToIdempotencyKeyMap = new Map();
       const uniq = new BufferSet();
@@ -1593,9 +1593,6 @@ class HTTP extends Server {
           throw new Error(`value: ${value} is invalid!`);
 
         const rawAddress = to.str('address');
-        //
-        console.log(this.network);
-        //
         const addr = parseAddress(rawAddress, this.network);
         addressToIdempotencyKeyMap.set(addr.toString(), {
           idempotencyKey: idempotencyKey,
@@ -1616,38 +1613,40 @@ class HTTP extends Server {
           return output;
       });
 
-      const options = {
-        outputs: outputs,
-        subtractFee: subtractFee,
-        account: account,
-        depth: minconf
-      };
+      if (outputs.length > 0) {
+        const options = {
+          outputs: outputs,
+          subtractFee: subtractFee,
+          account: account,
+          depth: minconf
+        };
 
-      const tx = await req.wallet.send(options, passphrase);
-      const txJSON = tx.toJSON();
-      const txOutputsLen = txJSON.outputs.length;
+        const tx = await req.wallet.send(options, passphrase);
+        const txJSON = tx.toJSON();
+        const txOutputsLen = txJSON.outputs.length;
 
-      // postprocess results
-      for (let i=0; i<txOutputsLen; i++) {
-         const output = txJSON.outputs[i];
-         if (addressToIdempotencyKeyMap.has(output.address)) {
-           const {idempotencyKey} = addressToIdempotencyKeyMap
-             .get(output.address);
+        // postprocess results
+        for (let i=0; i<txOutputsLen; i++) {
+           const output = txJSON.outputs[i];
+           if (addressToIdempotencyKeyMap.has(output.address)) {
+             const {idempotencyKey} = addressToIdempotencyKeyMap
+               .get(output.address);
 
-           const hsdTransfer =
-           {
-            idempotency_key: idempotencyKey,
-            tx_hash: tx.hash,
-            output_index: i,
-            output: output
-          };
+             const hsdTransfer =
+             {
+              idempotency_key: idempotencyKey,
+              tx_hash: tx.hash,
+              output_index: i,
+              output: output
+            };
 
-          results.push(hsdTransfer);
-          // populate cache
-          const cachedHsdTransfer = Object.assign({}, hsdTransfer);
-          cachedHsdTransfer.fromCache = true;
-          cache.set(cachedHsdTransfer.idempotency_key, cachedHsdTransfer);
-         }
+            results.push(hsdTransfer);
+            // populate cache
+            const cachedHsdTransfer = Object.assign({}, hsdTransfer);
+            cachedHsdTransfer.fromCache = true;
+            cache.set(cachedHsdTransfer.idempotency_key, cachedHsdTransfer);
+           }
+        }
       }
 
       return res.json(200, {processedWithdrawals: results});

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1571,7 +1571,7 @@ class HTTP extends Server {
       const results = [];
 
       for (const {idempotencyKey} of sendTo) {
-        if (cache.has(idempotencyKey)) {
+        if (idempotencyKey && cache.has(idempotencyKey)) {
           results.push(cache.get(idempotencyKey));
         }
       }
@@ -1584,12 +1584,17 @@ class HTTP extends Server {
 
       const outputs = filteredSendTo.map((element) => {
         const to = new Validator(element);
+
+        const idempotencyKey = to.str('idempotency_key');
+        if (!idempotencyKey)
+          throw new Error('idempotencyKey is missing!');
+
         const value   = to.u64('value');
         if (!value)
           throw new Error(`value: ${value} is invalid!`);
 
         const addr = parseAddress(to.str('address'), this.network);
-        addressToIdempotencyKeyMap.set(addr, element.idempotencyKey);
+        addressToIdempotencyKeyMap.set(addr, idempotencyKey);
 
         const hash = addr.getHash();
 
@@ -1614,20 +1619,26 @@ class HTTP extends Server {
 
       const tx = await req.wallet.send(options, passphrase);
       const txOutputsLen = tx.outputs.length;
+
+      console.log(txOutputsLen);
       // postprocess results
       for (let i=0; i<txOutputsLen; i++) {
          const output = tx.outputs[i];
+         console.log(output.address);
          if (addressToIdempotencyKeyMap.has(output.address)) {
-           results.push(
-             {
-              idempotencyKey: addressToIdempotencyKeyMap.get(output.address),
-              tx_hash: tx.hash,
-              output_index: i,
-              output: output
-            });
-            // populate cache as well
-            cache.put()
+           const hsdTransfer =
+           {
+            idempotency_key: addressToIdempotencyKeyMap.get(output.address),
+            tx_hash: tx.hash,
+            output_index: i,
+            output: output
+          };
 
+          results.push(hsdTransfer);
+          // populate cache
+          const cachedHsdTransfer = Object.assign({}, hsdTransfer);
+          cachedHsdTransfer.fromCache = true;
+          cache.set(cachedHsdTransfer.idempotency_key, cachedHsdTransfer);
          }
       }
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -31,7 +31,6 @@ const {Resource} = require('../dns/resource');
 const common = require('./common');
 // eslint-disable-next-line no-unused-vars
 const Wallet = require('./wallet');
-const {EXP} = require('../protocol/consensus');
 
 /**
  * HTTP
@@ -1593,8 +1592,15 @@ class HTTP extends Server {
         if (!value)
           throw new Error(`value: ${value} is invalid!`);
 
-        const addr = parseAddress(to.str('address'), this.network);
-        addressToIdempotencyKeyMap.set(addr, idempotencyKey);
+        const rawAddress = to.str('address');
+        //
+        console.log(this.network);
+        //
+        const addr = parseAddress(rawAddress, this.network);
+        addressToIdempotencyKeyMap.set(addr.toString(), {
+          idempotencyKey: idempotencyKey,
+          rawAddress: rawAddress
+        });
 
         const hash = addr.getHash();
 
@@ -1618,17 +1624,19 @@ class HTTP extends Server {
       };
 
       const tx = await req.wallet.send(options, passphrase);
-      const txOutputsLen = tx.outputs.length;
+      const txJSON = tx.toJSON();
+      const txOutputsLen = txJSON.outputs.length;
 
-      console.log(txOutputsLen);
       // postprocess results
       for (let i=0; i<txOutputsLen; i++) {
-         const output = tx.outputs[i];
-         console.log(output.address);
+         const output = txJSON.outputs[i];
          if (addressToIdempotencyKeyMap.has(output.address)) {
+           const {idempotencyKey} = addressToIdempotencyKeyMap
+             .get(output.address);
+
            const hsdTransfer =
            {
-            idempotency_key: addressToIdempotencyKeyMap.get(output.address),
+            idempotency_key: idempotencyKey,
             tx_hash: tx.hash,
             output_index: i,
             output: output

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1564,15 +1564,14 @@ class HTTP extends Server {
       const passphrase = valid.str('passphrase');
 
       if (sendTo.length === 0)
-         throw new Error('parameter sendto is required and can not be empty!');
+        throw new Error('parameter sendto is required and can not be empty!');
 
       const cache = req.wallet.hsdTransferResults;
       const results = [];
 
       for (const {idempotency_key: idempotencyKey} of sendTo) {
-        if (idempotencyKey && cache.has(idempotencyKey)) {
+        if (idempotencyKey && cache.has(idempotencyKey))
           results.push(cache.get(idempotencyKey));
-        }
       }
 
       const filteredSendTo = sendTo.filter(element =>
@@ -1602,7 +1601,7 @@ class HTTP extends Server {
         const hash = addr.getHash();
 
         if (uniq.has(hash))
-            throw new Error('Invalid parameter!');
+          throw new Error('Invalid parameter!');
 
           uniq.add(hash);
 
@@ -1622,18 +1621,18 @@ class HTTP extends Server {
         };
 
         const tx = await req.wallet.send(options, passphrase);
+
         const txJSON = tx.toJSON();
         const txOutputsLen = txJSON.outputs.length;
 
-        // postprocess results
         for (let i=0; i<txOutputsLen; i++) {
-           const output = txJSON.outputs[i];
-           if (addressToIdempotencyKeyMap.has(output.address)) {
-             const {idempotencyKey} = addressToIdempotencyKeyMap
-               .get(output.address);
+          const output = txJSON.outputs[i];
+          if (addressToIdempotencyKeyMap.has(output.address)) {
+            const {idempotencyKey} = addressToIdempotencyKeyMap
+              .get(output.address);
 
-             const hsdTransfer =
-             {
+            const hsdTransfer =
+            {
               idempotency_key: idempotencyKey,
               tx_hash: tx.hash,
               output_index: i,
@@ -1641,11 +1640,11 @@ class HTTP extends Server {
             };
 
             results.push(hsdTransfer);
-            // populate cache
+
             const cachedHsdTransfer = Object.assign({}, hsdTransfer);
             cachedHsdTransfer.fromCache = true;
             cache.set(cachedHsdTransfer.idempotency_key, cachedHsdTransfer);
-           }
+          }
         }
       }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -105,6 +105,7 @@ class Wallet extends EventEmitter {
       consensus.MAX_BLOCK_OPENS * updatesPerAuction * updatesCacheSizeInBlocks;
     this.sendUpdateResults = new LRU(updateCapacity);
 
+    this.hsdTransferResults = new LRU(25000);
     this.sendTransferResults = new LRU(25000);
     this.sendFinalizeResults = new LRU(25000);
 


### PR DESCRIPTION
This PR introduces the new sendmany endpoint (previously only present in rpc calls)

It expects the following request format:

```
{
    "account": "test",
    "passphrase": "",
    "subtractfee": false,
    "minconf": 2,
    "sendto": [
        {
          "idempotency_key": "a4",
          "address": "rs1q8m5g0g325wmxsudhht2uqqp3qx0wha48nkm4da",
          "value":5000
        },
        {
          "idempotency_key": "a5",
          "address": "rs1qz5nzwhqasgcsght65ajdy8u5syjt7wa76c3wkl",
          "value":5000
        }
    ]
}
```

And responds with following format:

```
{
    "processedWithdrawals": [
        {
            "idempotency_key": "a5",
            "output_index": 0,
            "output": {
                "value": 5000,
                "address": "hs1qz5nzwhqasgcsght65ajdy8u5syjt7wa7ez0dkd",
                "covenant": {
                    "type": 0,
                    "action": "NONE",
                    "items": []
                }
            }
        },
        {
            "idempotency_key": "a4",
            "output_index": 1,
            "output": {
                "value": 5000,
                "address": "hs1q8m5g0g325wmxsudhht2uqqp3qx0wha48sv9kd0",
                "covenant": {
                    "type": 0,
                    "action": "NONE",
                    "items": []
                }
            }
        }
    ]
}
```

2 things i noticed and wanted to draw your attention and ask for input is following:

**1.** parseAddress method, always returning the mainnet type of addresses (i learned the types from Anthony was not aware of address classes prior.)

So for following input (even tough the network is regtest) i get following output:

```
rs1q8m5g0g325wmxsudhht2uqqp3qx0wha48nkm4da --> Input

hs1qz5nzwhqasgcsght65ajdy8u5syjt7wa7ez0dkd --> Output
```

**2.** consecutive calls to sendmany results in `Not enough funds error` although the account have more than enough HNS.
  mining a block (to a different address) clears the error. Same behavior exists with rpc version as well.






