### PR TITLE
Blacklist rfc2606 domains from the dns resolver.

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -53,6 +53,20 @@ const TYPE_MAP = Buffer.from('000722000000000380', 'hex');
 const RES_OPT = { inet6: false, tcp: true };
 const CACHE_TTL = 30 * 60 * 1000;
 
+// reference: https://tools.ietf.org/id/draft-chapin-rfc2606bis-00.html#registry
+const rfc2606 = [
+  'corp',
+  'domain',
+  'example',
+  'home',
+  'host',
+  'invalid',
+  'lan',
+  'local',
+  'localdomain',
+  'localhost',
+  'test'
+];
 const blacklist = new Set([
   'bit', // Namecoin
   'eth', // ENS
@@ -61,7 +75,8 @@ const blacklist = new Set([
   'i2p', // Invisible Internet Project
   'onion', // Tor
   'tor', // OnioNS
-  'zkey' // GNS
+  'zkey', // GNS
+  ...rfc2606
 ]);
 
 /**


### PR DESCRIPTION
These domains were causing problems in the resolver

https://tools.ietf.org/id/draft-chapin-rfc2606bis-00.html#registry