### PR TITLE
Return an error response hsd-proxy can parse

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -955,16 +955,20 @@ class HTTP extends Server {
 
       const height = this.wdb.height;
       const network = this.network;
-
       /** @type {Wallet} */
       const wallet = req.wallet;
+      const notFound = () => res.json(
+        404,
+        {message: `${name} not found in wallet ${wallet.id}`}
+      );
+
       const ns = await wallet.getNameStateByName(name);
       if (!ns)
-        return res.json(404);
+        return notFound();
 
       const tx = await wallet.getTX(ns.owner.hash);
       if (!tx)
-        return res.json(404);
+        return notFound();
 
       const details = await wallet.toDetails(tx);
       const ownerOutput = details.outputs[ns.owner.index];
@@ -973,7 +977,7 @@ class HTTP extends Server {
         return res.json(200, ns.getJSON(height, network));
       }
 
-      return res.json(404, {success: true});
+      return notFound();
     });
 
     // Wallet Auctions


### PR DESCRIPTION
Saw a noisy error in honeycomb about not being able to parse an error response, this should fix it.

For reference, the error: https://ui.honeycomb.io/namebase/datasets/namebase-web/result/y5thSyxt1K9