### PR TITLE
Ridvan wallet backup

### DIFF
--- a/lib/hd/private.js
+++ b/lib/hd/private.js
@@ -244,7 +244,7 @@ class HDPrivateKey extends bio.Struct {
 
   deriveAccount(purpose, type, account) {
     assert((purpose >>> 0) === purpose, 'Purpose must be a number.');
-    assert((type >>> 0) === type, 'Account index must be a number.');
+    assert((type >>> 0) === type, 'Coin Type must be a number.');
     assert((account >>> 0) === account, 'Account index must be a number.');
     assert(this.isMaster(), 'Cannot derive account index.');
     return this

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -508,12 +508,18 @@ util.backupWallet = async function (wallet) {
     }
 
     const blinds = await wallet.getBlinds();
+    // each wallet must have a default account
+    const defaultAccount = accountsBackup[0];
 
     return {
       wallet: wallet.getJSON(),
       blinds,
       masterKeyData: masterKeyData,
+      // default account data
       accountKey: accountKey,
+      m: defaultAccount.m,
+      n: defaultAccount.n,
+      //
       accounts: accountsBackup
     };
   } finally {
@@ -543,14 +549,16 @@ util.backupAccount = async function (account) {
     keys
   } = account;
 
-  const keysBase58 = keys.map(key => key.xpubkey(this.network));
+  const network = account.network;
+  const accountKeyBase58 = accountKey.toBase58(network);
+  const keysBase58 = keys.map(key => key.xpubkey(network));
 
   return {
     name,
     type,
     m,
     n,
-    accountKey: accountKey.toBase58(account.network),
+    accountKey: accountKeyBase58,
     keys: keysBase58,
     receiveDepth,
     changeDepth
@@ -582,6 +590,8 @@ util.backupAccount = async function (account) {
  * @property {BlindBackup[]} blinds
  * @property {string} masterKeyData
  * @property {string} accountKey Base58 Representation of xpubkey
+ * @property {number} m required signature count
+ * @property {number} n total addresses
  * @property {AccountBackup[]} accounts
  */
 
@@ -601,8 +611,7 @@ util.restoreWallet = async function (walletBackup, wdb) {
   const masterKeyData = Buffer.from(walletBackup.masterKeyData, 'hex');
   const MasterKey = require('../wallet/masterkey');
   const masterKey = new MasterKey().readKey(masterKeyData);
-  const accountKey = walletBackup.accountKey;
-  const { wallet } = walletBackup;
+  const { wallet, accountKey, m, n } = walletBackup;
 
   const restoredWallet = await wdb.create({
     master: masterKey.key,
@@ -611,8 +620,10 @@ util.restoreWallet = async function (walletBackup, wdb) {
     watchOnly: wallet.watchOnly,
     token: Buffer.from(wallet.token, 'hex'),
     tokenDepth: wallet.tokenDepth,
-    // default account's xpub key
-    accountKey: accountKey
+    // default accounts creation
+    accountKey: accountKey,
+    m: m,
+    n: n
   });
 
   // restore blinds
@@ -678,6 +689,10 @@ util.restoreAccount = async function (wallet, accountBackup) {
 
   for (let j = 0; j < (changeDepth - 1); j++) {
     await wallet.createKey(name, 1);
+  }
+
+  for (const key of keys) {
+    await wallet.addSharedKey(name, key);
   }
 
   return null;

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -489,25 +489,33 @@ util.storeOneInCache = function (processedOutput, cache) {
  * @returns {Promise<WalletBackup>} WalletBackup
  */
 util.backupWallet = async function (wallet) {
-  const accountsBackup = [];
-  const accountNames = await wallet.getAccounts();
+  const unlock1 = await wallet.writeLock.lock();
+  const unlock2 = await wallet.fundLock.lock();
 
-  const masterKey = wallet.master;
-  const masterKeyData = masterKey.writeKey().toString('hex');
+  try {
+    const accountsBackup = [];
+    const accountNames = await wallet.getAccounts();
 
-  for (const accountName of accountNames) {
-    const account = await wallet.getAccount(accountName);
-    accountsBackup.push(await util.backupAccount(account));
+    const masterKey = wallet.master;
+    const masterKeyData = masterKey.writeKey().toString('hex');
+
+    for (const accountName of accountNames) {
+      const account = await wallet.getAccount(accountName);
+      accountsBackup.push(await util.backupAccount(account));
+    }
+
+    const blinds = await wallet.getBlinds();
+
+    return {
+      ...wallet.getJSON(),
+      blinds,
+      masterKeyData: masterKeyData,
+      accounts: accountsBackup
+    };
+  } finally {
+    unlock2();
+    unlock1();
   }
-
-  const blinds = await wallet.getBlinds();
-
-  return {
-    ...wallet.getJSON(),
-    blinds,
-    masterKeyData: masterKeyData,
-    accounts: accountsBackup
-  };
 };
 
 /**

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -10,6 +10,9 @@ const assert = require('bsert');
 const { types } = require('../covenants/rules');
 const fs = require('fs');
 const zlib = require('zlib');
+const Mnemonic = require('../hd/mnemonic');
+const HDPrivateKey = require('../hd/private');
+const MasterKey = require('../wallet/masterkey');
 
 /**
  * @exports utils/util
@@ -499,7 +502,7 @@ util.backupWallet = async function (wallet) {
     const accountNames = await wallet.getAccounts();
 
     const masterKey = wallet.master;
-    const masterKeyData = masterKey.writeKey().toString('hex');
+    const mnemonicPhrase = masterKey.mnemonic.getPhrase();
     const accountKey = (await wallet.accountKey()).xpubkey(wallet.network);
 
     for (const accountName of accountNames) {
@@ -514,7 +517,7 @@ util.backupWallet = async function (wallet) {
     return {
       wallet: wallet.getJSON(),
       blinds,
-      masterKeyData: masterKeyData,
+      mnemonicPhrase,
       // default account data
       accountKey: accountKey,
       m: defaultAccount.m,
@@ -588,7 +591,7 @@ util.backupAccount = async function (account) {
  * @typedef {Object} WalletBackup
  * @property {wallet} walletJSON
  * @property {BlindBackup[]} blinds
- * @property {string} masterKeyData
+ * @property {string} mnemonicPhrase mnemonic phrase
  * @property {string} accountKey Base58 Representation of xpubkey
  * @property {number} m required signature count
  * @property {number} n total addresses
@@ -608,9 +611,10 @@ util.backupAccount = async function (account) {
  * @returns {Promise<null>} ...
  */
 util.restoreWallet = async function (walletBackup, wdb) {
-  const masterKeyData = Buffer.from(walletBackup.masterKeyData, 'hex');
-  const MasterKey = require('../wallet/masterkey');
-  const masterKey = new MasterKey().readKey(masterKeyData);
+  const mnemonicPhrase = walletBackup.mnemonicPhrase;
+  const mnemonic = new Mnemonic({ phrase: mnemonicPhrase });
+  const key = HDPrivateKey.fromMnemonic(mnemonic);
+  const masterKey = new MasterKey({ mnemonic, key });
   const { wallet, accountKey, m, n } = walletBackup;
 
   const restoredWallet = await wdb.create({

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -7,7 +7,9 @@
 'use strict';
 
 const assert = require('bsert');
-const {types} = require('../covenants/rules');
+const { types } = require('../covenants/rules');
+const fs = require('fs');
+const zlib = require('zlib');
 
 /**
  * @exports utils/util
@@ -200,7 +202,7 @@ util.createBatch = function(limit, domainOutputMap) {
     throw new Error('invalid limit provided!');
 
   if (!domainOutputMap || domainOutputMap.entries().length === 0) {
-      throw new Error('Invalid map provided!');
+    throw new Error('Invalid map provided!');
   }
 
   const entriesArray = [...domainOutputMap.entries()];
@@ -211,26 +213,26 @@ util.createBatch = function(limit, domainOutputMap) {
   let totalNumberOfOutputs = 0;
 
   for (const [name, outputs] of entriesArray) {
-      const outputLen = totalNumberOfOutputs + outputs.length;
-      if (outputLen > limit) {
-        // if there is any space left, partially process the bids
-        // of this domain
-        const availableSpots = limit - totalNumberOfOutputs;
-        if (availableSpots > 0) {
-          totalNumberOfOutputs += availableSpots;
-          validDomains.push({name, bidCount: availableSpots});
-          const remainingBidsForDomain = outputs.length - availableSpots;
-          rejectedDomains.push({name, bidCount: remainingBidsForDomain});
-        } else {
-          rejectedDomains.push({name, bidCount: outputs.length});
-        }
+    const outputLen = totalNumberOfOutputs + outputs.length;
+    if (outputLen > limit) {
+      // if there is any space left, partially process the bids
+      // of this domain
+      const availableSpots = limit - totalNumberOfOutputs;
+      if (availableSpots > 0) {
+        totalNumberOfOutputs += availableSpots;
+        validDomains.push({ name, bidCount: availableSpots });
+        const remainingBidsForDomain = outputs.length - availableSpots;
+        rejectedDomains.push({ name, bidCount: remainingBidsForDomain });
       } else {
-          totalNumberOfOutputs += outputs.length;
-          validDomains.push({name, bidCount: outputs.length});
+        rejectedDomains.push({ name, bidCount: outputs.length });
       }
+    } else {
+      totalNumberOfOutputs += outputs.length;
+      validDomains.push({ name, bidCount: outputs.length });
+    }
   }
 
-  return {validDomains: validDomains, rejectedDomains: rejectedDomains};
+  return { validDomains: validDomains, rejectedDomains: rejectedDomains };
 };
 
 /**
@@ -249,7 +251,7 @@ util.createStrictBatch = function(limit, domainOutputMap) {
     throw new Error('invalid limit provided!');
 
   if (!domainOutputMap || domainOutputMap.entries().length === 0) {
-      throw new Error('Invalid map provided!');
+    throw new Error('Invalid map provided!');
   }
 
   const entriesArray = [...domainOutputMap.entries()];
@@ -262,13 +264,13 @@ util.createStrictBatch = function(limit, domainOutputMap) {
   for (const [name, outputs] of entriesArray) {
     const outputLen = totalNumberOfOutputs + outputs.length;
     if (outputLen > limit) {
-        rejectedDomains.push({name, bidCount: outputs.length});
+      rejectedDomains.push({ name, bidCount: outputs.length });
     } else {
-        totalNumberOfOutputs += outputs.length;
-        validDomains.push({name, bidCount: outputs.length});
+      totalNumberOfOutputs += outputs.length;
+      validDomains.push({ name, bidCount: outputs.length });
     }
-}
-  return {validDomains: validDomains, rejectedDomains: rejectedDomains};
+  }
+  return { validDomains: validDomains, rejectedDomains: rejectedDomains };
 };
 
 /**
@@ -283,7 +285,7 @@ util.createStrictBatch = function(limit, domainOutputMap) {
 util.postProcessBatchBids = function(txHash, txOutputs, mtxOutputs) {
   const processedBids = [];
 
-  for (let i=0; i<txOutputs.length; i++) {
+  for (let i = 0; i < txOutputs.length; i++) {
     const txOutput  = txOutputs[i];
     if (txOutput.covenant.type === types.BID) {
       processedBids.push({
@@ -473,7 +475,7 @@ util.storeMultipleInCache = function (processedOutput, cache) {
 util.storeOneInCache = function (processedOutput, cache) {
   const placer = function (placerCache, item) {
     const idempotencyKey = item.idempotency_key;
-      placerCache.set(idempotencyKey, item);
+    placerCache.set(idempotencyKey, item);
   };
 
   this.storeInCache(processedOutput, cache, placer);
@@ -501,13 +503,13 @@ util.backupWallet = async function (wallet) {
 
     for (const accountName of accountNames) {
       const account = await wallet.getAccount(accountName);
-      accountsBackup.push(await util.backupAccount(account));
+      accountsBackup.push(await this.backupAccount(account));
     }
 
     const blinds = await wallet.getBlinds();
 
     return {
-      ...wallet.getJSON(),
+      wallet: wallet.getJSON(),
       blinds,
       masterKeyData: masterKeyData,
       accounts: accountsBackup
@@ -552,13 +554,7 @@ util.backupAccount = async function (account) {
 };
 
 /**
- * @typedef {Object} BlindBackup
- * @property {number} value
- * @property {string} nonce
- */
-
-/**
- * @typedef {Object} WalletBackup
+ * @typedef {Object} WalletJSON
  * @property {string} network
  * @property {number} wid
  * @property {string} id
@@ -568,6 +564,17 @@ util.backupAccount = async function (account) {
  * @property {number} tokenDepth
  * @property {Object} master
  * @property {Object} balance
+ */
+
+/**
+ * @typedef {Object} BlindBackup
+ * @property {number} value
+ * @property {string} nonce
+ */
+
+/**
+ * @typedef {Object} WalletBackup
+ * @property {wallet} walletJSON
  * @property {BlindBackup[]} blinds
  * @property {string} masterKeyData
  * @property {AccountBackup[]} accounts
@@ -589,19 +596,20 @@ util.restoreWallet = async function (walletBackup, wdb) {
   const masterKeyData = Buffer.from(walletBackup.masterKeyData, 'hex');
   const MasterKey = require('../wallet/masterkey');
   const masterKey = new MasterKey().readKey(masterKeyData);
+  const { wallet } = walletBackup;
 
   const restoredWallet = await wdb.create({
-      master: masterKey.key,
-      wid: walletBackup.wid,
-      id: walletBackup.id,
-      watchOnly: walletBackup.watchOnly,
-      token: Buffer.from(walletBackup.token, 'hex'),
-      tokenDepth: walletBackup.tokenDepth
+    master: masterKey.key,
+    wid: wallet.wid,
+    id: wallet.id,
+    watchOnly: wallet.watchOnly,
+    token: Buffer.from(wallet.token, 'hex'),
+    tokenDepth: wallet.tokenDepth
   });
 
   // restore blinds
   const blinds = walletBackup.blinds;
-  for (const {value, nonce} of blinds) {
+  for (const { value, nonce } of blinds) {
     await restoredWallet.saveBlind(value, Buffer.from(nonce, 'hex'));
   }
 
@@ -653,12 +661,12 @@ util.restoreAccount = async function (wallet, accountBackup) {
     keys
   });
 
-  for (let i=0; i<(receiveDepth-1); i++) {
-      await wallet.createKey(name, 0);
+  for (let i = 0; i < (receiveDepth - 1); i++) {
+    await wallet.createKey(name, 0);
   }
 
-  for (let j=0; j<(changeDepth-1); j++) {
-      await wallet.createKey(name, 1);
+  for (let j = 0; j < (changeDepth - 1); j++) {
+    await wallet.createKey(name, 1);
   }
 
   return null;
@@ -672,8 +680,6 @@ util.restoreAccount = async function (wallet, accountBackup) {
  * @returns {Buffer} unzipped contents
  */
 util.unzipFile = function (filePath) {
-  const fs = require('fs');
-
   if (!filePath) {
     throw new Error('filepath is invalid (null|undefined)!');
   }
@@ -683,7 +689,7 @@ util.unzipFile = function (filePath) {
   }
 
   const buffer = fs.readFileSync(filePath);
-  return require('zlib').unzipSync(buffer);
+  zlib.unzipSync(buffer);
 };
 
 /**
@@ -694,40 +700,5 @@ util.unzipFile = function (filePath) {
  * @returns {Buffer} compressed contents of object
  */
 util.zipObject = function (object) {
-  return require('zlib').gzipSync(Buffer.from(JSON.stringify(object)));
-};
-
-/**
-* Return a timestamp with the format "d/m/yy h:MM:ss TT"
-* @type {Date}
-*/
-
-util.timeStamp = function timeStamp() {
-// Create a date object with the current time
- const now = new Date();
-
-// Create an array with the current month, day and time
- const date = [now.getDate(), now.getMonth() + 1, now.getFullYear()];
-
-// Create an array with the current hour, minute and second
- const time = [now.getHours(), now.getMinutes(), now.getSeconds()];
-
-// Determine AM or PM suffix based on the hour
- // const suffix = (time[0] < 12) ? 'AM' : 'PM';
-
-// Convert hour from military time
- // time[0] = (time[0] < 12) ? time[0] : time[0] - 12;
-
-// If hour is 0, set it to 12
- // time[0] = time[0] || 12;
-
-// If seconds and minutes are less than 10, add a zero
- for (let i = 1; i < 3; i++) {
-   if (time[i] < 10) {
-     time[i] = '0' + time[i];
-   }
- }
-
-// Return the formatted string
- return date.join('/') + '_' + time.join(':');
+  return zlib.gzipSync(Buffer.from(JSON.stringify(object)));
 };

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -480,9 +480,13 @@ util.storeOneInCache = function (processedOutput, cache) {
 };
 
 /**
- *
- * @param {Wallet} wallet
- * @returns
+ * @typedef {import('../wallet/wallet)} Wallet
+ */
+
+/**
+ * Creates a backup from provided wallet
+ * @param {Wallet} wallet wallet
+ * @returns {Promise<WalletBackup>} WalletBackup
  */
 util.backupWallet = async function (wallet) {
   const accountsBackup = [];
@@ -507,9 +511,13 @@ util.backupWallet = async function (wallet) {
 };
 
 /**
- *
- * @param {Account} account
- * @returns
+ * @typedef {import('../wallet/account')} Account
+ */
+
+/**
+ * Creates a Backup from provided account object
+ * @param {Account} account ...
+ * @returns {Promise<AccountBackup>} AccountBackup
  */
 util.backupAccount = async function (account) {
   const {
@@ -536,10 +544,38 @@ util.backupAccount = async function (account) {
 };
 
 /**
+ * @typedef {Object} BlindBackup
+ * @property {number} value
+ * @property {string} nonce
+ */
+
+/**
+ * @typedef {Object} WalletBackup
+ * @property {string} network
+ * @property {number} wid
+ * @property {string} id
+ * @property {boolean} watchOnly
+ * @property {number} accountDepth
+ * @property {string} token
+ * @property {number} tokenDepth
+ * @property {Object} master
+ * @property {Object} balance
+ * @property {BlindBackup[]} blinds
+ * @property {string} masterKeyData
+ * @property {AccountBackup[]} accounts
+ */
+
+/**
+ * @typedef {import('../wallet/walletdb')} WalletDB
+ */
+
+/**
+ * Restores Wallet from a Backup
+ *
  * @async
- * @param {*} walletBackup
- * @param {WDB} wdb
- * @returns
+ * @param {WalletBackup} walletBackup ...
+ * @param {WalletDB} wdb ...
+ * @returns {Promise<null>} ...
  */
 util.restoreWallet = async function (walletBackup, wdb) {
   const masterKeyData = Buffer.from(walletBackup.masterKeyData, 'hex');
@@ -565,13 +601,30 @@ util.restoreWallet = async function (walletBackup, wdb) {
   for (const accountBackup of walletBackup.accounts) {
     await util.restoreAccount(restoredWallet, accountBackup);
   }
+
+  return null;
 };
 
 /**
+ * @typedef {Object} AccountBackup
+ * @property {string} name Account Name
+ * @property {string} type Account Type
+ * @property {number} m M
+ * @property {number} n N
+ * @property {string[]} keys multisig keys (if m!=n and > 1)
+ * @property {number} receiveDepth number of receive addresses derived
+ * @property {number} changeDepth number of change addresses derived
+ *
+ */
+
+/**
+ * Restores an account and attaches it to the wallet
+ * using Backup
  *
  * @async
- * @param {Wallet} wallet
- * @param {*} accountBackup
+ * @param {module:wallet.Wallet} wallet Wallet to attach account to
+ * @param {AccountBackup} accountBackup AccountBackup object to restore
+ * @returns {Promise<null>} null
  */
 util.restoreAccount = async function (wallet, accountBackup) {
   const {
@@ -599,6 +652,41 @@ util.restoreAccount = async function (wallet, accountBackup) {
   for (let j=0; j<(changeDepth-1); j++) {
       await wallet.createKey(name, 1);
   }
+
+  return null;
+};
+
+/**
+ * Unzips a file and returns contents
+ * throws an error if something goes wrong
+ *
+ * @param {string} filePath local file path
+ * @returns {Buffer} unzipped contents
+ */
+util.unzipFile = function (filePath) {
+  const fs = require('fs');
+
+  if (!filePath) {
+    throw new Error('filepath is invalid (null|undefined)!');
+  }
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File: ${filePath} does not exist!`);
+  }
+
+  const buffer = fs.readFileSync(filePath);
+  return require('zlib').unzipSync(buffer);
+};
+
+/**
+ * Serialized an object into string with JSON.stringfy
+ * and zips the contents into a Buffer
+ *
+ * @param {Object} object to serializes to JSON and compress
+ * @returns {Buffer} compressed contents of object
+ */
+util.zipObject = function (object) {
+  return require('zlib').gzipSync(Buffer.from(JSON.stringify(object)));
 };
 
 /**

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -10,9 +10,6 @@ const assert = require('bsert');
 const { types } = require('../covenants/rules');
 const fs = require('fs');
 const zlib = require('zlib');
-const Mnemonic = require('../hd/mnemonic');
-const HDPrivateKey = require('../hd/private');
-const MasterKey = require('../wallet/masterkey');
 
 /**
  * @exports utils/util
@@ -20,7 +17,7 @@ const MasterKey = require('../wallet/masterkey');
 
 const util = exports;
 
-/**
+/**®
  * Return hrtime (shim for browser).
  * @param {Array} time
  * @returns {Array} [seconds, nanoseconds]
@@ -612,13 +609,10 @@ util.backupAccount = async function (account) {
  */
 util.restoreWallet = async function (walletBackup, wdb) {
   const mnemonicPhrase = walletBackup.mnemonicPhrase;
-  const mnemonic = new Mnemonic({ phrase: mnemonicPhrase });
-  const key = HDPrivateKey.fromMnemonic(mnemonic);
-  const masterKey = new MasterKey({ mnemonic, key });
   const { wallet, accountKey, m, n } = walletBackup;
 
   const restoredWallet = await wdb.create({
-    master: masterKey.key,
+    mnemonic: mnemonicPhrase,
     wid: wallet.wid,
     id: wallet.id,
     watchOnly: wallet.watchOnly,

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -500,6 +500,7 @@ util.backupWallet = async function (wallet) {
 
     const masterKey = wallet.master;
     const masterKeyData = masterKey.writeKey().toString('hex');
+    const accountKey = (await wallet.accountKey()).xpubkey(wallet.network);
 
     for (const accountName of accountNames) {
       const account = await wallet.getAccount(accountName);
@@ -512,6 +513,7 @@ util.backupWallet = async function (wallet) {
       wallet: wallet.getJSON(),
       blinds,
       masterKeyData: masterKeyData,
+      accountKey: accountKey,
       accounts: accountsBackup
     };
   } finally {
@@ -535,6 +537,7 @@ util.backupAccount = async function (account) {
     type,
     m,
     n,
+    accountKey,
     receiveDepth,
     changeDepth,
     keys
@@ -547,6 +550,7 @@ util.backupAccount = async function (account) {
     type,
     m,
     n,
+    accountKey: accountKey.toBase58(account.network),
     keys: keysBase58,
     receiveDepth,
     changeDepth
@@ -577,6 +581,7 @@ util.backupAccount = async function (account) {
  * @property {wallet} walletJSON
  * @property {BlindBackup[]} blinds
  * @property {string} masterKeyData
+ * @property {string} accountKey Base58 Representation of xpubkey
  * @property {AccountBackup[]} accounts
  */
 
@@ -596,6 +601,7 @@ util.restoreWallet = async function (walletBackup, wdb) {
   const masterKeyData = Buffer.from(walletBackup.masterKeyData, 'hex');
   const MasterKey = require('../wallet/masterkey');
   const masterKey = new MasterKey().readKey(masterKeyData);
+  const accountKey = walletBackup.accountKey;
   const { wallet } = walletBackup;
 
   const restoredWallet = await wdb.create({
@@ -604,7 +610,9 @@ util.restoreWallet = async function (walletBackup, wdb) {
     id: wallet.id,
     watchOnly: wallet.watchOnly,
     token: Buffer.from(wallet.token, 'hex'),
-    tokenDepth: wallet.tokenDepth
+    tokenDepth: wallet.tokenDepth,
+    // default account's xpub key
+    accountKey: accountKey
   });
 
   // restore blinds
@@ -627,6 +635,7 @@ util.restoreWallet = async function (walletBackup, wdb) {
  * @property {string} type Account Type
  * @property {number} m M
  * @property {number} n N
+ * @property {string} accountKey Base58 encoded xpubkey
  * @property {string[]} keys multisig keys (if m!=n and > 1)
  * @property {number} receiveDepth number of receive addresses derived
  * @property {number} changeDepth number of change addresses derived
@@ -648,6 +657,7 @@ util.restoreAccount = async function (wallet, accountBackup) {
     type,
     m,
     n,
+    accountKey,
     keys,
     receiveDepth,
     changeDepth
@@ -658,6 +668,7 @@ util.restoreAccount = async function (wallet, accountBackup) {
     type,
     m,
     n,
+    accountKey,
     keys
   });
 
@@ -689,7 +700,7 @@ util.unzipFile = function (filePath) {
   }
 
   const buffer = fs.readFileSync(filePath);
-  zlib.unzipSync(buffer);
+  return zlib.unzipSync(buffer);
 };
 
 /**

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -478,3 +478,160 @@ util.storeOneInCache = function (processedOutput, cache) {
 
   this.storeInCache(processedOutput, cache, placer);
 };
+
+/**
+ *
+ * @param {Wallet} wallet
+ * @returns
+ */
+util.backupWallet = async function (wallet) {
+  const accountsBackup = [];
+  const accountNames = await wallet.getAccounts();
+
+  const masterKey = wallet.master;
+  const masterKeyData = masterKey.writeKey().toString('hex');
+
+  for (const accountName of accountNames) {
+    const account = await wallet.getAccount(accountName);
+    accountsBackup.push(await util.backupAccount(account));
+  }
+
+  const blinds = await wallet.getBlinds();
+
+  return {
+    ...wallet.getJSON(),
+    blinds,
+    masterKeyData: masterKeyData,
+    accounts: accountsBackup
+  };
+};
+
+/**
+ *
+ * @param {Account} account
+ * @returns
+ */
+util.backupAccount = async function (account) {
+  const {
+    name,
+    type,
+    m,
+    n,
+    receiveDepth,
+    changeDepth,
+    keys
+  } = account;
+
+  const keysBase58 = keys.map(key => key.xpubkey(this.network));
+
+  return {
+    name,
+    type,
+    m,
+    n,
+    keys: keysBase58,
+    receiveDepth,
+    changeDepth
+  };
+};
+
+/**
+ * @async
+ * @param {*} walletBackup
+ * @param {WDB} wdb
+ * @returns
+ */
+util.restoreWallet = async function (walletBackup, wdb) {
+  const masterKeyData = Buffer.from(walletBackup.masterKeyData, 'hex');
+  const MasterKey = require('../wallet/masterkey');
+  const masterKey = new MasterKey().readKey(masterKeyData);
+
+  const restoredWallet = await wdb.create({
+      master: masterKey.key,
+      wid: walletBackup.wid,
+      id: walletBackup.id,
+      watchOnly: walletBackup.watchOnly,
+      token: Buffer.from(walletBackup.token, 'hex'),
+      tokenDepth: walletBackup.tokenDepth
+  });
+
+  // restore blinds
+  const blinds = walletBackup.blinds;
+  for (const {value, nonce} of blinds) {
+    await restoredWallet.saveBlind(value, Buffer.from(nonce, 'hex'));
+  }
+
+  // restore accounts
+  for (const accountBackup of walletBackup.accounts) {
+    await util.restoreAccount(restoredWallet, accountBackup);
+  }
+};
+
+/**
+ *
+ * @async
+ * @param {Wallet} wallet
+ * @param {*} accountBackup
+ */
+util.restoreAccount = async function (wallet, accountBackup) {
+  const {
+    name,
+    type,
+    m,
+    n,
+    keys,
+    receiveDepth,
+    changeDepth
+  } = accountBackup;
+
+  await wallet.ensureAccount({
+    name,
+    type,
+    m,
+    n,
+    keys
+  });
+
+  for (let i=0; i<(receiveDepth-1); i++) {
+      await wallet.createKey(name, 0);
+  }
+
+  for (let j=0; j<(changeDepth-1); j++) {
+      await wallet.createKey(name, 1);
+  }
+};
+
+/**
+* Return a timestamp with the format "d/m/yy h:MM:ss TT"
+* @type {Date}
+*/
+
+util.timeStamp = function timeStamp() {
+// Create a date object with the current time
+ const now = new Date();
+
+// Create an array with the current month, day and time
+ const date = [now.getDate(), now.getMonth() + 1, now.getFullYear()];
+
+// Create an array with the current hour, minute and second
+ const time = [now.getHours(), now.getMinutes(), now.getSeconds()];
+
+// Determine AM or PM suffix based on the hour
+ // const suffix = (time[0] < 12) ? 'AM' : 'PM';
+
+// Convert hour from military time
+ // time[0] = (time[0] < 12) ? time[0] : time[0] - 12;
+
+// If hour is 0, set it to 12
+ // time[0] = time[0] || 12;
+
+// If seconds and minutes are less than 10, add a zero
+ for (let i = 1; i < 3; i++) {
+   if (time[i] < 10) {
+     time[i] = '0' + time[i];
+   }
+ }
+
+// Return the formatted string
+ return date.join('/') + '_' + time.join(':');
+};

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -2008,8 +2008,7 @@ class HTTP extends Server {
         backup.push(walletBackup);
       }
 
-      const zlib = require('zlib');
-      const buffer = zlib.gzipSync(Buffer.from(JSON.stringify(backup)));
+      const buffer = util.zipObject(backup);
       const backupName = `walletBackup_${util.timeStamp()}.json.gzip`;
       res.setHeader('Content-Disposition', `inline; filename="${backupName}"`);
       res.buffer(200, buffer);
@@ -2019,6 +2018,22 @@ class HTTP extends Server {
     this.post('/walletrestore', async (req, res) => {
       const backup = req.body.backup;
       
+      for (const walletBackup of backup) {
+        // Skip primary
+        if (walletBackup.id === 'primary') {
+          continue;
+        }
+        await util.restoreWallet(walletBackup, this.wdb);
+      }
+      res.json(200, {});
+    });
+
+    this.post('/walletrestorefromfile', async (req, res) => {
+
+      const filePath = req.body.backupFilePath;
+      const buffer = util.unzipFile(filePath);
+      const backup = JSON.parse(buffer.toString('utf8'));
+
       for (const walletBackup of backup) {
         // Skip primary
         if (walletBackup.id === 'primary') {

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -2019,7 +2019,7 @@ class HTTP extends Server {
 
       for (const walletBackup of backup) {
         // Skip primary
-        if (walletBackup.id === 'primary') {
+        if (walletBackup.wallet.id === 'primary') {
           continue;
         }
         await util.restoreWallet(walletBackup, this.wdb);

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -2030,7 +2030,9 @@ class HTTP extends Server {
 
     this.post('/walletrestorefromfile', async (req, res) => {
 
-      const filePath = req.body.backupFilePath;
+      const valid = Validator.fromRequest(req);
+      const filePath = valid.str('filePath');
+      
       const buffer = util.unzipFile(filePath);
       const backup = JSON.parse(buffer.toString('utf8'));
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -2014,10 +2014,9 @@ class HTTP extends Server {
       res.buffer(200, buffer);
     });
 
-    /* eslint-disable */
     this.post('/walletrestore', async (req, res) => {
       const backup = req.body.backup;
-      
+
       for (const walletBackup of backup) {
         // Skip primary
         if (walletBackup.id === 'primary') {
@@ -2029,10 +2028,9 @@ class HTTP extends Server {
     });
 
     this.post('/walletrestorefromfile', async (req, res) => {
-
       const valid = Validator.fromRequest(req);
       const filePath = valid.str('filePath');
-      
+
       const buffer = util.unzipFile(filePath);
       const backup = JSON.parse(buffer.toString('utf8'));
 
@@ -2046,7 +2044,6 @@ class HTTP extends Server {
       res.json(200, {});
     });
   }
-  /* eslint-enable */
 
   /**
    * Initialize websockets.

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1993,6 +1993,50 @@ class HTTP extends Server {
 
       res.json(200, { success: true });
     });
+
+    /* eslint-disable */
+    this.post('/walletbackup', async (req, res) => {
+      
+      const backup = [];
+      const walletIds = await this.wdb.getWallets();
+
+      for (const wid of walletIds) {
+        const walletData = {};
+
+        const wallet = await this.wdb.get(wid);
+        const mnemonic = wallet.master.mnemonic;
+
+        // TODO lock wallet
+        
+        // Private Key Backup
+        const keyBuffer = await wallet.master.writeKey();        
+        walletData.masterKey = keyBuffer.toString('hex');
+        walletData.mnemonic = mnemonic;
+
+        const accountsBackup = [];
+        const walletAccounts = await wallet.getAccounts();        
+        for (const accountName of walletAccounts) {
+          // Take account backup
+          const account = await wallet.getAccount(accountName);
+          const recvDepth = account.receiveDepth;
+          const changeDepth = account.changeDepth; 
+
+          const accountBackup = {
+            name: accountName,
+            recvDepth: recvDepth,
+            changeDepth: changeDepth
+          };
+                    
+          accountsBackup.push(accountBackup);
+        }
+        
+        walletData.accounts = accountsBackup;
+        backup.push({ walletId: wid, data: walletData });
+      }
+
+      res.json(200, {backup});
+    });
+    /* eslint-enable */
   }
 
   /**

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -31,7 +31,7 @@ const {Resource} = require('../dns/resource');
 const common = require('./common');
 // eslint-disable-next-line no-unused-vars
 const Wallet = require('./wallet');
-const util = require('../utils/util');
+const {util} = require('../utils');
 const { nextTick } = require('process');
 
 /**
@@ -1994,50 +1994,42 @@ class HTTP extends Server {
       res.json(200, { success: true });
     });
 
-    /* eslint-disable */
-    this.post('/walletbackup', async (req, res) => {
-      
+    this.get('/walletbackup', async (req, res) => {
       const backup = [];
       const walletIds = await this.wdb.getWallets();
 
-      for (const wid of walletIds) {
-        const walletData = {};
-
-        const wallet = await this.wdb.get(wid);
-        const mnemonic = wallet.master.mnemonic;
-
-        // TODO lock wallet
-        
-        // Private Key Backup
-        const keyBuffer = await wallet.master.writeKey();        
-        walletData.masterKey = keyBuffer.toString('hex');
-        walletData.mnemonic = mnemonic;
-
-        const accountsBackup = [];
-        const walletAccounts = await wallet.getAccounts();        
-        for (const accountName of walletAccounts) {
-          // Take account backup
-          const account = await wallet.getAccount(accountName);
-          const recvDepth = account.receiveDepth;
-          const changeDepth = account.changeDepth; 
-
-          const accountBackup = {
-            name: accountName,
-            recvDepth: recvDepth,
-            changeDepth: changeDepth
-          };
-                    
-          accountsBackup.push(accountBackup);
+      for (const walletId of walletIds) {
+        if (walletId === 'primary') {
+          continue;
         }
-        
-        walletData.accounts = accountsBackup;
-        backup.push({ walletId: wid, data: walletData });
+
+        const wallet = await this.wdb.get(walletId);
+        const walletBackup = await util.backupWallet(wallet);
+        backup.push(walletBackup);
       }
 
-      res.json(200, {backup});
+      const zlib = require('zlib');
+      const buffer = zlib.gzipSync(Buffer.from(JSON.stringify(backup)));
+      const backupName = `walletBackup_${util.timeStamp()}.json.gzip`;
+      res.setHeader('Content-Disposition', `inline; filename="${backupName}"`);
+      res.buffer(200, buffer);
     });
-    /* eslint-enable */
+
+    /* eslint-disable */
+    this.post('/walletrestore', async (req, res) => {
+      const backup = req.body.backup;
+      
+      for (const walletBackup of backup) {
+        // Skip primary
+        if (walletBackup.id === 'primary') {
+          continue;
+        }
+        await util.restoreWallet(walletBackup, this.wdb);
+      }
+      res.json(200, {});
+    });
   }
+  /* eslint-enable */
 
   /**
    * Initialize websockets.

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -9,9 +9,9 @@
 
 const assert = require('bsert');
 const path = require('path');
-const {Server} = require('bweb');
+const { Server } = require('bweb');
 const Validator = require('bval');
-const {BufferSet} = require('buffer-map');
+const { BufferSet } = require('buffer-map');
 const base58 = require('bcrypto/lib/encoding/base58');
 const MTX = require('../primitives/mtx');
 const Outpoint = require('../primitives/outpoint');
@@ -20,18 +20,18 @@ const sha256 = require('bcrypto/lib/sha256');
 const rules = require('../covenants/rules');
 const random = require('bcrypto/lib/random');
 const Covenant = require('../primitives/covenant');
-const {safeEqual} = require('bcrypto/lib/safe');
+const { safeEqual } = require('bcrypto/lib/safe');
 const Network = require('../protocol/network');
 const Address = require('../primitives/address');
 const KeyRing = require('../primitives/keyring');
 const Mnemonic = require('../hd/mnemonic');
 const HDPrivateKey = require('../hd/private');
 const HDPublicKey = require('../hd/public');
-const {Resource} = require('../dns/resource');
+const { Resource } = require('../dns/resource');
 const common = require('./common');
 // eslint-disable-next-line no-unused-vars
 const Wallet = require('./wallet');
-const {util} = require('../utils');
+const { util } = require('../utils');
 const { nextTick } = require('process');
 
 /**
@@ -276,10 +276,10 @@ class HTTP extends Server {
           wallet.clearCache(cacheName);
         }
       } catch (err) {
-        return res.json(400, {error: err.message});
+        return res.json(400, { error: err.message });
       }
 
-      return res.json(200, {message: 'ok'});
+      return res.json(200, { message: 'ok' });
     });
 
     // Clear specific cache key
@@ -292,10 +292,10 @@ class HTTP extends Server {
           wallet.clearCache(cacheName, cacheKey);
         }
       } catch (err) {
-        return res.json(400, {error: err.message});
+        return res.json(400, { error: err.message });
       }
 
-      return res.json(200, {message: 'ok'});
+      return res.json(200, { message: 'ok' });
     });
 
     // List wallets
@@ -995,7 +995,7 @@ class HTTP extends Server {
       const wallet = req.wallet;
       const notFound = () => res.json(
         404,
-        {message: `${name} not found in wallet ${wallet.id}`}
+        { message: `${name} not found in wallet ${wallet.id}` }
       );
 
       const ns = await wallet.getNameStateByName(name);
@@ -1229,7 +1229,7 @@ class HTTP extends Server {
       }
 
       const options = TransactionOptions.fromValidator(valid);
-      const {result, fromCache} = await req.wallet.withOpenCache(
+      const { result, fromCache } = await req.wallet.withOpenCache(
         idempotencyKey,
         () => {
           return req.wallet.createOpen(name, force, options);
@@ -1265,22 +1265,22 @@ class HTTP extends Server {
       assert(broadcast ? sign : true, 'Must sign when broadcasting.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const {mtx, errors, isAllError} = await req.wallet
+      const { mtx, errors, isAllError } = await req.wallet
                                         .createBatchOpen(names, force, options);
 
       if (isAllError) // no valid output in mtx
-        return res.json(500, {errors: errors});
+        return res.json(500, { errors: errors });
 
       if (broadcast) {
         const tx = await req.wallet.sendMTX(mtx, passphrase);
-        return res.json(200, {tx: tx.getJSON(this.network), errors: errors});
+        return res.json(200, { tx: tx.getJSON(this.network), errors: errors });
       }
 
       if (sign) {
         await req.wallet.sign(mtx, passphrase);
       }
 
-      return res.json(200, {tx: mtx.getJSON(this.network), errors: errors});
+      return res.json(200, { tx: mtx.getJSON(this.network), errors: errors });
     });
 
     // Create Bid
@@ -1307,7 +1307,7 @@ class HTTP extends Server {
 
       const options = TransactionOptions.fromValidator(valid);
 
-      const {result, fromCache} = await req.wallet.withBidCache(
+      const { result, fromCache } = await req.wallet.withBidCache(
         idempotencyKey,
         () => {
           return req.wallet.createBid(name, bid, lockup, options);
@@ -1363,8 +1363,8 @@ class HTTP extends Server {
         }
       });
 
-     // add value property (same as bid) to each bid
-     // value property is same with bid property and used internally
+      // add value property (same as bid) to each bid
+      // value property is same with bid property and used internally
       bids = bids.map((element) => {
         element['value'] = element.bid;
         return element;
@@ -1388,7 +1388,7 @@ class HTTP extends Server {
       }
 
       if (uniqueBids.length > 0) {
-        const {mtx, errorMessages} = await req.wallet
+        const { mtx, errorMessages } = await req.wallet
           .createBatchBid(uniqueBids, options);
 
         errors = errorMessages;
@@ -1496,20 +1496,20 @@ class HTTP extends Server {
       assert(broadcast ? sign : true, 'Must sign when broadcasting.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const {mtx, errorMessages} = await req.wallet
+      const { mtx, errorMessages } = await req.wallet
         .createBatchReveal(names, options);
 
       if (broadcast) {
         const tx = await req.wallet.sendMTX(mtx, passphrase);
-        return res.json(200, {tx: tx.getJSON(this.network),
-          errors: errorMessages});
+        return res.json(200, { tx: tx.getJSON(this.network),
+          errors: errorMessages });
       }
 
       if (sign)
         await req.wallet.sign(mtx, passphrase);
 
-      return res.json(200, {tx: mtx.getJSON(this.network),
-        errorMessages: errorMessages});
+      return res.json(200, { tx: mtx.getJSON(this.network),
+        errorMessages: errorMessages });
     });
 
     // Create Batch Reveal
@@ -1527,7 +1527,7 @@ class HTTP extends Server {
         .retrieveMultipleFromCache(revealCache, names);
 
       if (uniqueNames.length === 0) {
-        return res.json(200, {processedReveals, errors: []});
+        return res.json(200, { processedReveals, errors: [] });
       }
 
       const batchRevealResponse = await req.wallet
@@ -1547,7 +1547,7 @@ class HTTP extends Server {
         nameHashMap.set(nameHash, name);
       }
 
-      const {outputs, hash: txHash} = txJSON;
+      const { outputs, hash: txHash } = txJSON;
 
       outputs.forEach((output, index) => {
         if (output.covenant.type === rules.types.REVEAL) {
@@ -1560,7 +1560,7 @@ class HTTP extends Server {
         }
       });
 
-      return res.json(200, {processedReveals, errors: errorMessages});
+      return res.json(200, { processedReveals, errors: errorMessages });
     });
 
     // Create Batch Finish (Redeem or Register)
@@ -1584,8 +1584,8 @@ class HTTP extends Server {
         dataValidator.array('records');
       });
 
-      const formattedFinishRequests = finishRequests.map(({name, data}) => {
-        return {name, data: Resource.fromJSON(data)};
+      const formattedFinishRequests = finishRequests.map(({ name, data }) => {
+        return { name, data: Resource.fromJSON(data) };
       });
 
       const options = TransactionOptions.fromValidator(valid);
@@ -1594,10 +1594,10 @@ class HTTP extends Server {
       const uniqueNames = [];
       const processedFinishes = [];
 
-      formattedFinishRequests.forEach(({name, data}) => {
+      formattedFinishRequests.forEach(({ name, data }) => {
         const cachedResponse = finishCache.get(name);
         if (!cachedResponse) {
-          uniqueNames.push({name, data});
+          uniqueNames.push({ name, data });
         } else {
           cachedResponse.forEach(cachedName =>
             processedFinishes.push(cachedName));
@@ -1607,7 +1607,7 @@ class HTTP extends Server {
       let errorMessages = [];
       if (uniqueNames.length > 0) {
         const nameHashMap = new Map();
-        uniqueNames.forEach(({name, data}) => {
+        uniqueNames.forEach(({ name, data }) => {
           const nameHash = rules.hashName(name).toString('hex');
           nameHashMap.set(nameHash, name);
         });
@@ -1694,7 +1694,7 @@ class HTTP extends Server {
 
       const options = TransactionOptions.fromValidator(valid);
 
-      const {result, fromCache} = await req.wallet.withBidCache(
+      const { result, fromCache } = await req.wallet.withBidCache(
         idempotencyKey,
         () => {
           return req.wallet.createUpdate(name, resource, options);
@@ -1782,7 +1782,7 @@ class HTTP extends Server {
 
       const addr = Address.fromString(address, this.network);
       const options = TransactionOptions.fromValidator(valid);
-      const {result, fromCache} = await req.wallet.withTransferCache(
+      const { result, fromCache } = await req.wallet.withTransferCache(
         idempotencyKey,
         () => {
           return req.wallet.createTransfer(name, addr, options);
@@ -1840,7 +1840,7 @@ class HTTP extends Server {
       assert(name, 'Must pass name.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const {result, fromCache} = await req.wallet.withFinalizeCache(
+      const { result, fromCache } = await req.wallet.withFinalizeCache(
         idempotencyKey,
         () => {
           return req.wallet.createFinalize(name, options);
@@ -1900,7 +1900,7 @@ class HTTP extends Server {
       const cache = req.wallet.hsdTransferResults;
       const results = [];
 
-      for (const {idempotency_key: idempotencyKey} of sendTo) {
+      for (const { idempotency_key: idempotencyKey } of sendTo) {
         if (idempotencyKey && cache.has(idempotencyKey))
           results.push(cache.get(idempotencyKey));
       }
@@ -1934,13 +1934,13 @@ class HTTP extends Server {
         if (uniq.has(hash))
           throw new Error('Invalid parameter!');
 
-          uniq.add(hash);
+        uniq.add(hash);
 
-          const output = new Output();
-          output.value = value;
-          output.address = addr;
+        const output = new Output();
+        output.value = value;
+        output.address = addr;
 
-          return output;
+        return output;
       });
 
       if (outputs.length > 0) {
@@ -1956,10 +1956,10 @@ class HTTP extends Server {
         const txJSON = tx.toJSON();
         const txOutputsLen = txJSON.outputs.length;
 
-        for (let i=0; i<txOutputsLen; i++) {
+        for (let i = 0; i < txOutputsLen; i++) {
           const output = txJSON.outputs[i];
           if (addressToIdempotencyKeyMap.has(output.address)) {
-            const {idempotencyKey} = addressToIdempotencyKeyMap
+            const { idempotencyKey } = addressToIdempotencyKeyMap
               .get(output.address);
 
             const hsdTransfer =
@@ -1979,7 +1979,7 @@ class HTTP extends Server {
         }
       }
 
-      return res.json(200, {processedWithdrawals: results});
+      return res.json(200, { processedWithdrawals: results });
     });
 
     // resync wallet db
@@ -1999,32 +1999,15 @@ class HTTP extends Server {
       const walletIds = await this.wdb.getWallets();
 
       for (const walletId of walletIds) {
-        if (walletId === 'primary') {
-          continue;
-        }
-
         const wallet = await this.wdb.get(walletId);
         const walletBackup = await util.backupWallet(wallet);
         backup.push(walletBackup);
       }
 
       const buffer = util.zipObject(backup);
-      const backupName = `walletBackup_${util.timeStamp()}.json.gzip`;
+      const backupName = `walletBackup_${new Date().toISOString()}.json.gzip`;
       res.setHeader('Content-Disposition', `inline; filename="${backupName}"`);
       res.buffer(200, buffer);
-    });
-
-    this.post('/walletrestore', async (req, res) => {
-      const backup = req.body.backup;
-
-      for (const walletBackup of backup) {
-        // Skip primary
-        if (walletBackup.id === 'primary') {
-          continue;
-        }
-        await util.restoreWallet(walletBackup, this.wdb);
-      }
-      res.json(200, {});
     });
 
     this.post('/walletrestorefromfile', async (req, res) => {

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -731,6 +731,28 @@ class TXDB {
   }
 
   /**
+   * Retrieve all blinds that belong to a wallet
+   * @async
+   * @param {Number} wid
+   * @return  {Promise<BlindValue[]>}
+   */
+
+  async getBlinds() {
+    const iter = this.bucket.iterator({
+      gte: layout.v.min(),
+      lte: layout.v.max(),
+      values: true
+    });
+
+    const blinds = [];
+    await iter.each((k, value) => {
+      blinds.push(BlindValue.decode(value));
+    });
+
+    return blinds;
+  }
+
+  /**
    * Write a blind value.
    * @param {Object} b
    * @param {Buffer} blind

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1372,6 +1372,17 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Saves blind into txdb used with restore
+   * @param {Number} value value
+   * @param {Buffer} nonce nonce
+   * @returns {Promise<void>} save result
+   */
+  saveBlind(value, nonce) {
+    const blind = rules.blind(value, nonce);
+    return this.txdb.saveBlind(blind, {value, nonce});
+  }
+
+  /**
    * Make a claim MTX.
    * @param {String} name
    * @returns {Claim}
@@ -5434,6 +5445,14 @@ class Wallet extends EventEmitter {
 
   inspect() {
     return this.format();
+  }
+
+  /**
+   * Retrieves all blinds for this wallet
+   * @returns {Promise<BlindValue[]>} BlindValues
+   */
+  getBlinds() {
+    return this.txdb.getBlinds();
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -9,7 +9,7 @@
 
 const assert = require('bsert');
 const EventEmitter = require('events');
-const {Lock} = require('bmutex');
+const { Lock } = require('bmutex');
 const base58 = require('bcrypto/lib/encoding/base58');
 const bio = require('bufio');
 const blake2b = require('bcrypto/lib/blake2b');
@@ -31,14 +31,14 @@ const MasterKey = require('./masterkey');
 const policy = require('../protocol/policy');
 const consensus = require('../protocol/consensus');
 const rules = require('../covenants/rules');
-const {Resource} = require('../dns/resource');
+const { Resource } = require('../dns/resource');
 const Claim = require('../primitives/claim');
 const reserved = require('../covenants/reserved');
 const ownership = require('../covenants/ownership');
-const {states} = require('../covenants/namestate');
-const {types} = rules;
-const {Mnemonic} = HD;
-const {BufferSet} = require('buffer-map');
+const { states } = require('../covenants/namestate');
+const { types } = rules;
+const { Mnemonic } = HD;
+const { BufferSet } = require('buffer-map');
 const util = require('../utils/util');
 
 /**
@@ -1349,7 +1349,7 @@ class Wallet extends EventEmitter {
     const lo = value >>> 0;
     const index = (hi ^ lo) & 0x7fffffff;
 
-    const {publicKey} = account.accountKey.derive(index);
+    const { publicKey } = account.accountKey.derive(index);
 
     return blake2b.multi(address.hash, publicKey, nameHash);
   }
@@ -1366,7 +1366,7 @@ class Wallet extends EventEmitter {
     const nonce = await this.generateNonce(nameHash, address, value);
     const blind = rules.blind(value, nonce);
 
-    await this.txdb.saveBlind(blind, {value, nonce});
+    await this.txdb.saveBlind(blind, { value, nonce });
 
     return blind;
   }
@@ -1379,7 +1379,7 @@ class Wallet extends EventEmitter {
    */
   saveBlind(value, nonce) {
     const blind = rules.blind(value, nonce);
-    return this.txdb.saveBlind(blind, {value, nonce});
+    return this.txdb.saveBlind(blind, { value, nonce });
   }
 
   /**
@@ -1557,7 +1557,7 @@ class Wallet extends EventEmitter {
         throw new Error('Name is not available.');
     }
 
-    const {proof, txt} = await this._createClaim(name, options);
+    const { proof, txt } = await this._createClaim(name, options);
 
     if (!proof)
       throw new Error('Could not resolve name.');
@@ -1691,7 +1691,7 @@ class Wallet extends EventEmitter {
 
     for (const name of names) {
       if (!rules.verifyName(name)) {
-        errorMessages.push({name: name, error: `Invalid name: "${name}".`});
+        errorMessages.push({ name: name, error: `Invalid name: "${name}".` });
         continue;
       }
 
@@ -1702,12 +1702,12 @@ class Wallet extends EventEmitter {
 
       // TODO: Handle expired behavior.
       if (rules.isReserved(nameHash, height, network)) {
-        errorMessages.push({name: name, error: `Name is reserved: "${name}".`});
+        errorMessages.push({ name: name, error: `Name is reserved: "${name}".` });
         continue;
       }
 
       if (!rules.hasRollout(nameHash, height, network)) {
-        errorMessages.push({name: name, error: `Name not yet available: "${name}".`});
+        errorMessages.push({ name: name, error: `Name not yet available: "${name}".` });
         continue;
       }
 
@@ -1722,12 +1722,12 @@ class Wallet extends EventEmitter {
       const start = ns.height;
 
       if (state !== states.OPENING) {
-        errorMessages.push({name: name, error: `Name is not available: "${name}".`});
+        errorMessages.push({ name: name, error: `Name is not available: "${name}".` });
         continue;
       }
 
       if (start !== 0 && start !== height) {
-        errorMessages.push({name: name, error: `Name is already opening: "${name}".`});
+        errorMessages.push({ name: name, error: `Name is already opening: "${name}".` });
         continue;
       }
 
@@ -1742,7 +1742,7 @@ class Wallet extends EventEmitter {
       output.covenant.push(rawName);
 
       if (await this.txdb.isCovenantDoubleOpen(output.covenant)) {
-        errorMessages.push({name: name, error: `Already sent an open for: ${name}.`});
+        errorMessages.push({ name: name, error: `Already sent an open for: ${name}.` });
         continue;
       }
 
@@ -1750,7 +1750,7 @@ class Wallet extends EventEmitter {
     }
 
     const isAllError = (names.length === errorMessages.length);
-    return { mtx: mtx, errors: errorMessages, isAllError: isAllError};
+    return { mtx: mtx, errors: errorMessages, isAllError: isAllError };
   }
 
   /**
@@ -1764,14 +1764,14 @@ class Wallet extends EventEmitter {
 
   async _createBatchOpen(names, force, options) {
     const acct = options ? options.account || 0 : 0;
-    const {mtx, errors, isAllError} = await this
+    const { mtx, errors, isAllError } = await this
       .makeBatchOpen(names, force, acct);
     if (!isAllError) {
-        await this.fill(mtx, options);
-        const finalizedMtx = await this.finalize(mtx, options);
-        return {mtx: finalizedMtx, errors: errors};
+      await this.fill(mtx, options);
+      const finalizedMtx = await this.finalize(mtx, options);
+      return { mtx: finalizedMtx, errors: errors };
     } else {
-      return {mtx: null, errors: errors, isAllError: true};
+      return { mtx: null, errors: errors, isAllError: true };
     }
   }
 
@@ -1803,7 +1803,7 @@ class Wallet extends EventEmitter {
    */
 
   async _createOpen(name, force, options) {
-    const {mtx, errors, isAllError} = await this._createBatchOpen(Array.of(name), force, options);
+    const { mtx, errors, isAllError } = await this._createBatchOpen(Array.of(name), force, options);
     if (isAllError) {
       throw new Error(errors[0].error);
     } else{
@@ -1879,7 +1879,7 @@ class Wallet extends EventEmitter {
     }
   }
 
-   /**
+  /**
    * Make a bid MTX.
    * @param {String} name
    * @param {Number} value
@@ -1889,8 +1889,8 @@ class Wallet extends EventEmitter {
    */
 
   async makeBid(name, value, lockup, acct) {
-    const {mtx} = await this.makeBatchBid([
-      {name, value, lockup}
+    const { mtx } = await this.makeBatchBid([
+      { name, value, lockup }
     ], acct);
     return mtx;
   }
@@ -1911,7 +1911,7 @@ class Wallet extends EventEmitter {
 
     for (const bid of bids) {
       try {
-        const {name, value, lockup} = bid;
+        const { name, value, lockup } = bid;
         const output = await this.processBid(name, value, lockup, acct, consecutiveCall);
         consecutiveCall = true;
 
@@ -1933,7 +1933,7 @@ class Wallet extends EventEmitter {
       throw new Error(errorMessages[0].error);
     }
 
-    return {mtx, errorMessages};
+    return { mtx, errorMessages };
   }
 
   /**
@@ -2014,10 +2014,10 @@ class Wallet extends EventEmitter {
 
   async _createBid(bids, options) {
     const acct = options ? options.account || 0 : 0;
-    let {mtx, errorMessages} = await this.makeBatchBid(bids, acct);
+    let { mtx, errorMessages } = await this.makeBatchBid(bids, acct);
     await this.fill(mtx, options);
     mtx = await this.finalize(mtx, options);
-    return {mtx, errorMessages};
+    return { mtx, errorMessages };
   }
 
   /**
@@ -2033,7 +2033,7 @@ class Wallet extends EventEmitter {
   async createBid(name, value, lockup, options) {
     const unlock = await this.fundLock.lock();
     try {
-      const {mtx} = await this._createBid([{name, value, lockup}], options);
+      const { mtx } = await this._createBid([{ name, value, lockup }], options);
       return mtx;
     } finally {
       unlock();
@@ -2059,7 +2059,7 @@ class Wallet extends EventEmitter {
 
   async _sendBid(name, value, lockup, options) {
     const passphrase = options ? options.passphrase : null;
-    const {mtx} = await this._createBid([{name, value, lockup}], options);
+    const { mtx } = await this._createBid([{ name, value, lockup }], options);
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2073,7 +2073,7 @@ class Wallet extends EventEmitter {
    */
   static async doWithCache(cache, idempotencyKey, callback) {
     if (idempotencyKey && cache.has(idempotencyKey)) {
-      return {result: cache.get(idempotencyKey), fromCache: true};
+      return { result: cache.get(idempotencyKey), fromCache: true };
     }
 
     const result = await callback();
@@ -2081,7 +2081,7 @@ class Wallet extends EventEmitter {
       cache.set(idempotencyKey, result);
     }
 
-    return {result: result, fromCache: false};
+    return { result: result, fromCache: false };
   }
 
   async withBidCache(idempotencyKey, bidCallback) {
@@ -2136,7 +2136,7 @@ class Wallet extends EventEmitter {
     const unlock = await this.fundLock.lock();
     try {
       const idempotencyKey = options ? options.idempotencyKey : null;
-      const {result} = await this.withBidCache(idempotencyKey,
+      const { result } = await this.withBidCache(idempotencyKey,
         () => this._sendBid(name, value, lockup, options)
       );
       return result;
@@ -2179,7 +2179,7 @@ class Wallet extends EventEmitter {
    */
 
   async _createAuctionTxs(name, value, lockup, options) {
-    const {mtx: bid} = await this._createBid([{name, value, lockup}], options);
+    const { mtx: bid } = await this._createBid([{ name, value, lockup }], options);
 
     const bidOuputIndex = bid.outputs.findIndex(o => o.covenant.isBid());
     const bidOutput = bid.outputs[bidOuputIndex];
@@ -2236,7 +2236,7 @@ class Wallet extends EventEmitter {
 
     const mtx = new MTX();
     const outputs = this.processNameForReveal(name, acct);
-    for (const {outpoint, output} of outputs) {
+    for (const { outpoint, output } of outputs) {
       mtx.addOutpoint(outpoint);
       mtx.outputs.push(output);
     }
@@ -2282,11 +2282,11 @@ class Wallet extends EventEmitter {
 
     const outputs = [];// {outpoint, output}
 
-    for (const {prevout, own} of bids) {
+    for (const { prevout, own } of bids) {
       if (!own)
         continue;
 
-      const {hash, index} = prevout;
+      const { hash, index } = prevout;
       const coin = await this.getCoin(hash, index);
 
       if (!coin)
@@ -2305,7 +2305,7 @@ class Wallet extends EventEmitter {
       if (!bv)
         throw new Error(`Blind value not found: "${domainName}".`);
 
-      const {value, nonce} = bv;
+      const { value, nonce } = bv;
 
       const output = new Output();
       output.address = coin.address;
@@ -2315,7 +2315,7 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
       output.covenant.pushHash(nonce);
 
-      outputs.push({outpoint: prevout, output: output});
+      outputs.push({ outpoint: prevout, output: output });
     }
 
     return outputs;
@@ -2340,17 +2340,17 @@ class Wallet extends EventEmitter {
     const outputMap = new Map();
 
     for (const domainName of names) {
-        try {
-          const outputs = await this.processNameForReveal(domainName, acct);
-          if (outputs.length === 0) {
-            throw new Error(`No bids to reveal: "${domainName}".`);
-          }
-          // store results for crafting the mtx
-          outputMap.set(domainName, outputs);
-        } catch (err) {
-          errorMessages.push({ name: domainName, error: err.message });
-          continue;
+      try {
+        const outputs = await this.processNameForReveal(domainName, acct);
+        if (outputs.length === 0) {
+          throw new Error(`No bids to reveal: "${domainName}".`);
         }
+        // store results for crafting the mtx
+        outputMap.set(domainName, outputs);
+      } catch (err) {
+        errorMessages.push({ name: domainName, error: err.message });
+        continue;
+      }
     }
 
     // to ensure the same behavior for makeReveal (single name)
@@ -2363,21 +2363,21 @@ class Wallet extends EventEmitter {
       throw new Error('Invalid (Batch) Reveal Request');
     }
 
-    const {validDomains, rejectedDomains} = util
+    const { validDomains, rejectedDomains } = util
     .createStrictBatch(MAX_REVEALS_PER_BATCH_TX, outputMap);
     const mtx = new MTX();
-    for (const {name, bidCount} of validDomains) {
+    for (const { name, bidCount } of validDomains) {
       // create final transaction, consisting of permitted number of bids
       const outputs = outputMap.get(name).slice(0, bidCount);
-      for (const {outpoint, output} of outputs) {
+      for (const { outpoint, output } of outputs) {
         mtx.addOutpoint(outpoint);
         mtx.outputs.push(output);
       }
     }
-    for (const {name, bidCount} of rejectedDomains) {
-      errorMessages.push({name: name,
+    for (const { name, bidCount } of rejectedDomains) {
+      errorMessages.push({ name: name,
         // eslint-disable-next-line max-len
-        error: `Not processing ${name} since it's bidCount of ${bidCount} output size is exceeding allowed cumulative output size`});
+        error: `Not processing ${name} since it's bidCount of ${bidCount} output size is exceeding allowed cumulative output size` });
     }
 
     return { mtx, errorMessages };
@@ -2393,10 +2393,10 @@ class Wallet extends EventEmitter {
 
   async _createBatchReveal(names, options) {
     const acct = options ? options.account : null;
-    const {mtx, errorMessages} = await this.makeBatchReveal(names, acct);
+    const { mtx, errorMessages } = await this.makeBatchReveal(names, acct);
     await this.fill(mtx, options);
     const finalizedMtx = await this.finalize(mtx, options);
-    return {mtx: finalizedMtx, errorMessages: errorMessages};
+    return { mtx: finalizedMtx, errorMessages: errorMessages };
   }
 
   /**
@@ -2427,7 +2427,7 @@ class Wallet extends EventEmitter {
   async createReveal(name, options) {
     const unlock = await this.fundLock.lock();
     try {
-      const {mtx} = await this._createBatchReveal([name], options);
+      const { mtx } = await this._createBatchReveal([name], options);
       return mtx;
     } finally {
       unlock();
@@ -2442,7 +2442,7 @@ class Wallet extends EventEmitter {
 
   async _sendReveal(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const {mtx} = await this._createBatchReveal([name], options);
+    const { mtx } = await this._createBatchReveal([name], options);
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2472,7 +2472,7 @@ class Wallet extends EventEmitter {
     const bids = await this.getBids();
     const mtx = new MTX();
 
-    for (const {nameHash, prevout, own} of bids) {
+    for (const { nameHash, prevout, own } of bids) {
       if (!own)
         continue;
 
@@ -2491,7 +2491,7 @@ class Wallet extends EventEmitter {
       if (state > states.REVEAL)
         continue;
 
-      const {hash, index} = prevout;
+      const { hash, index } = prevout;
       const coin = await this.getCoin(hash, index);
 
       if (!coin)
@@ -2507,7 +2507,7 @@ class Wallet extends EventEmitter {
       if (!bv)
         throw new Error('Blind value not found.');
 
-      const {value, nonce} = bv;
+      const { value, nonce } = bv;
 
       const output = new Output();
       output.address = coin.address;
@@ -2620,8 +2620,8 @@ class Wallet extends EventEmitter {
 
     const mtx = new MTX();
 
-    for (const {prevout, own} of reveals) {
-      const {hash, index} = prevout;
+    for (const { prevout, own } of reveals) {
+      const { hash, index } = prevout;
 
       if (!own)
         continue;
@@ -2692,8 +2692,8 @@ class Wallet extends EventEmitter {
     const reveals = await this.txdb.getReveals(nameHash);
     const outpoints = [];
 
-    for (const {prevout, own} of reveals) {
-      const {hash, index} = prevout;
+    for (const { prevout, own } of reveals) {
+      const { hash, index } = prevout;
 
       if (!own)
         continue;
@@ -2723,7 +2723,7 @@ class Wallet extends EventEmitter {
         output.value = ns.value;
         const raw = resource.encode();
         if (raw.length > rules.MAX_RESOURCE_SIZE)
-            throw new Error(`Resource exceeds maximum size: "${name}".`);
+          throw new Error(`Resource exceeds maximum size: "${name}".`);
         output.covenant.push(raw);
         output.covenant.pushHash(await this.wdb.getRenewalBlock());
       }
@@ -2753,7 +2753,7 @@ class Wallet extends EventEmitter {
     const MAX_FINISH_COUNT = 200;
     let currentLength = 0;
 
-    for (const {name, data: resource} of names) {
+    for (const { name, data: resource } of names) {
       try {
         // Contains Redeems and/or Register
         const finishes = await this.processNameForFinish(name, resource, acct);
@@ -2768,22 +2768,22 @@ class Wallet extends EventEmitter {
         currentLength = targetLength;
 
         finishes.forEach((element) => {
-          const {output, outpoint} = element;
+          const { output, outpoint } = element;
           mtx.addOutpoint(outpoint);
           mtx.outputs.push(output);
         });
       } catch (err) {
-        errorMessages.push({name: name, errorMessage: err.toString()});
+        errorMessages.push({ name: name, errorMessage: err.toString() });
       }
     }
 
     if (mtx.outputs.length === 0)
       throw new Error('No reveals to redeem or register!');
 
-    return {mtx, errorMessages};
+    return { mtx, errorMessages };
   }
 
- /**
+  /**
    * Create and finalize a redeem
    * MTX without a lock.
    * @param {Array<String>} name
@@ -2793,7 +2793,7 @@ class Wallet extends EventEmitter {
 
   async _createBatchFinish(names, options) {
     const acct = options ? options.account : null;
-    const {mtx, errorMessages} = await this.makeBatchFinish(names, acct);
+    const { mtx, errorMessages } = await this.makeBatchFinish(names, acct);
     await this.fill(mtx, options);
     const returnObj = {
       mtx: await this.finalize(mtx, options),
@@ -2892,8 +2892,8 @@ class Wallet extends EventEmitter {
     const reveals = await this.txdb.getReveals();
     const mtx = new MTX();
 
-    for (const {nameHash, prevout, own} of reveals) {
-      const {hash, index} = prevout;
+    for (const { nameHash, prevout, own } of reveals) {
+      const { hash, index } = prevout;
 
       const ns = await this.getNameState(nameHash);
 
@@ -3021,7 +3021,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3099,7 +3099,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3182,7 +3182,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3256,7 +3256,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3411,7 +3411,7 @@ class Wallet extends EventEmitter {
     const unlock = await this.fundLock.lock();
     try {
       const idempotencyKey = options ? options.idempotencyKey : null;
-      const {result} = await this.withUpdateCache(idempotencyKey,
+      const { result } = await this.withUpdateCache(idempotencyKey,
         () => this._sendUpdate(name, resource, options)
       );
       return result;
@@ -3465,7 +3465,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3601,7 +3601,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3742,7 +3742,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -3870,7 +3870,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -4013,7 +4013,7 @@ class Wallet extends EventEmitter {
     if (!ns)
       throw new Error(`Auction not found: "${name}".`);
 
-    const {hash, index} = ns.owner;
+    const { hash, index } = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
@@ -4765,9 +4765,9 @@ class Wallet extends EventEmitter {
    * @returns {Promise} - Returns {BufferSet} with Hash
    */
 
-   async getPendingAncestors(tx) {
+  async getPendingAncestors(tx) {
     return this._getPendingAncestors(tx, new BufferSet());
-   }
+  }
 
   /**
    * Get pending ancestors up to the policy limit.
@@ -4777,7 +4777,7 @@ class Wallet extends EventEmitter {
    */
 
   async _getPendingAncestors(tx, set) {
-    for (const {prevout} of tx.inputs) {
+    for (const { prevout } of tx.inputs) {
       const hash = prevout.hash;
 
       if (set.has(hash))
@@ -5570,24 +5570,24 @@ class Wallet extends EventEmitter {
    * @param {String | undefined} cacheKey
    */
 
-   clearCache(cacheName, cacheKey) {
-      let cache;
-      if(cacheName === 'bid') {
-        cache = this.sendBidResults;
-      } else if (cacheName === 'open') {
-        cache = this.sendOpenResults;
-      } else if (cacheName === 'update') {
-        cache = this.sendUpdateResults;
-      } else {
-        throw new Error(`invalid cache name: ${cacheName}`);
-      }
+  clearCache(cacheName, cacheKey) {
+    let cache;
+    if(cacheName === 'bid') {
+      cache = this.sendBidResults;
+    } else if (cacheName === 'open') {
+      cache = this.sendOpenResults;
+    } else if (cacheName === 'update') {
+      cache = this.sendUpdateResults;
+    } else {
+      throw new Error(`invalid cache name: ${cacheName}`);
+    }
 
-      if (cacheKey === null || cacheKey === undefined || cacheKey === '') {
-        cache.reset();
-      } else {
-        cache.remove(cacheKey);
-      }
-   }
+    if (cacheKey === null || cacheKey === undefined || cacheKey === '') {
+      cache.reset();
+    } else {
+      cache.remove(cacheKey);
+    }
+  }
 }
 
 /*

--- a/test/utils/util-test.js
+++ b/test/utils/util-test.js
@@ -56,5 +56,25 @@ describe('util', function() {
       assert.deepStrictEqual(validDomains.map(element => element.name), [domain1, domain2, domain3]);
       assert(rejectedDomains.length === 1);
     });
+
+    it('should create a zip from object and unzip it back from file', function() {
+      const fs = require('fs');
+      const os = require('os');
+      const path = require('path');
+
+      const object = {
+        // Voyager, greeting, https://voyager.jpl.nasa.gov/golden-record/whats-on-the-record/greetings/
+        greeting: 'Dear Turkish-speaking friends, may the honors of the morning be upon your heads.'
+      };
+
+      const writeBuffer = util.zipObject(object);
+
+      const filePath = path.join(os.tmpdir(), 'ziptest.zip');
+      fs.writeFileSync(filePath, writeBuffer);
+      const readBuffer = util.unzipFile(filePath);
+      const unzippedObject = JSON.parse(readBuffer.toString('utf8'));
+
+      assert.equal(object.greeting, unzippedObject.greeting);
+    });
   });
 });

--- a/test/utils/util-test.js
+++ b/test/utils/util-test.js
@@ -3,6 +3,10 @@
 const util = require('../../lib/utils/util');
 const assert = require('bsert');
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 describe('util', function() {
   describe('createBatch and createStrictBatch', function() {
     const outputMap = new Map();
@@ -35,11 +39,11 @@ describe('util', function() {
     it('should create a partial batch with domains that fit in pre-defined limit (ordered by the number of bids per domain descending)', function() {
       const limit = 99;
       const { validDomains, rejectedDomains } = util.createBatch(limit, outputMap);
-      assert.deepStrictEqual(validDomains, [{name: domain1, bidCount: limit}]);
-      const expectedRejectedDomains = [{name: domain1, bidCount: outputMap.get(domain1).length - limit},
-      {name: domain2, bidCount: outputMap.get(domain2).length},
-      {name: domain3, bidCount: outputMap.get(domain3).length},
-      {name: domain4, bidCount: outputMap.get(domain4).length}];
+      assert.deepStrictEqual(validDomains, [{ name: domain1, bidCount: limit }]);
+      const expectedRejectedDomains = [{ name: domain1, bidCount: outputMap.get(domain1).length - limit },
+      { name: domain2, bidCount: outputMap.get(domain2).length },
+      { name: domain3, bidCount: outputMap.get(domain3).length },
+      { name: domain4, bidCount: outputMap.get(domain4).length }];
       assert.deepStrictEqual(rejectedDomains, expectedRejectedDomains);
     });
 
@@ -58,10 +62,6 @@ describe('util', function() {
     });
 
     it('should create a zip from object and unzip it back from file', function() {
-      const fs = require('fs');
-      const os = require('os');
-      const path = require('path');
-
       const object = {
         // Voyager, greeting, https://voyager.jpl.nasa.gov/golden-record/whats-on-the-record/greetings/
         greeting: 'Dear Turkish-speaking friends, may the honors of the morning be upon your heads.'


### PR DESCRIPTION
This PR contains the new wallet backup endpoints along with a new method to retrieve blinds. We basically backup only the blinds and accounts and master key per wallet. During backup we are locking the wallet with fundLock and writeLock. During restore, we are not holding or using any locks (since we will be creating new wallets). 

3 new endpoints are introduced 
- one for backup, which returns a zipped json formatted backup file
- 2 for restore (one from zipped local file, one from json object)

**production-namebase** branch currently has 25 tests failing, since i merged it to my own branch i do have 25 tests failing as well, which was 3 since i last checked.

I will move this endpoint to namebase-plugin, once we have completed inspection and all good to go.
