### PR TITLE
revert tests from null open to reduce number of failing test

### DIFF
--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2050,7 +2050,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 1); // OPENs are sent to a null address
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, fund);
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -2069,7 +2069,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 1);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -2086,7 +2086,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2104,7 +2104,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2121,7 +2121,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, value);
@@ -2139,7 +2139,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, value);
@@ -2184,7 +2184,7 @@ describe('Wallet', function() {
       assert.strictEqual(bal.tx, 5);
       // Wallet coin count doesn't change:
       // REVEAL + fee money -> REGISTER + change
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -2202,7 +2202,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 5);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -2217,7 +2217,7 @@ describe('Wallet', function() {
       // Check
       const senderBal1 = await wallet.getBalance();
       assert.strictEqual(senderBal1.tx, 6);
-      assert.strictEqual(senderBal1.coin, 3);
+      assert.strictEqual(senderBal1.coin, 4);
       assert.strictEqual(senderBal1.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(senderBal1.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(senderBal1.ulocked, secondHighest);
@@ -2243,7 +2243,7 @@ describe('Wallet', function() {
       // Check
       const senderBal2 = await wallet.getBalance();
       assert.strictEqual(senderBal2.tx, 6);
-      assert.strictEqual(senderBal2.coin, 3);
+      assert.strictEqual(senderBal2.coin, 4);
       assert.strictEqual(senderBal2.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(senderBal2.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(senderBal2.ulocked, secondHighest);
@@ -2269,7 +2269,7 @@ describe('Wallet', function() {
       const senderBal3 = await wallet.getBalance();
       assert.strictEqual(senderBal3.tx, 7);
       // One less wallet coin because name UTXO belongs to recip now
-      assert.strictEqual(senderBal3.coin, 2);
+      assert.strictEqual(senderBal3.coin, 3);
       assert.strictEqual(senderBal3.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(senderBal3.unconfirmed, fund - secondHighest - (uTXCount * fee));
       assert.strictEqual(senderBal3.ulocked, 0);
@@ -2298,7 +2298,7 @@ describe('Wallet', function() {
       // Check
       senderBalBefore = await wallet.getBalance();
       assert.strictEqual(senderBalBefore.tx, 7);
-      assert.strictEqual(senderBalBefore.coin, 2);
+      assert.strictEqual(senderBalBefore.coin, 3);
       assert.strictEqual(senderBalBefore.confirmed, fund - secondHighest - (cTXCount * fee));
       assert.strictEqual(senderBalBefore.unconfirmed, fund - secondHighest - (uTXCount * fee));
       assert.strictEqual(senderBalBefore.ulocked, 0);
@@ -2331,7 +2331,7 @@ describe('Wallet', function() {
       // Check
       const senderBal4 = await wallet.getBalance();
       assert.strictEqual(senderBal4.tx, 7);
-      assert.strictEqual(senderBal4.coin, 2);
+      assert.strictEqual(senderBal4.coin, 3);
       assert.strictEqual(senderBal4.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(senderBal4.unconfirmed, fund - secondHighest - (uTXCount * fee));
       assert.strictEqual(senderBal4.ulocked, 0);
@@ -2435,7 +2435,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 1);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -2451,7 +2451,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 1);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -2470,7 +2470,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2486,7 +2486,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2505,7 +2505,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, value);
@@ -2547,7 +2547,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.ulocked, value);
@@ -2568,7 +2568,7 @@ describe('Wallet', function() {
       assert.strictEqual(bal.tx, 5);
       // Wallet coin count doesn't change:
       // REVEAL + fee money -> REGISTER + change
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -2585,7 +2585,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 5);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -2604,7 +2604,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 6);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -2620,7 +2620,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 6);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -2640,7 +2640,7 @@ describe('Wallet', function() {
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 7);
       // Coin count reduced by giving away name UTXO
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, fund - secondHighest - (cTXCount * fee));
       assert.strictEqual(bal.unconfirmed, fund - secondHighest - (uTXCount * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -3027,7 +3027,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 1);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, fund);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, 0);
@@ -3045,7 +3045,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 1);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, 0);
@@ -3063,7 +3063,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, lockup);
@@ -3090,7 +3090,7 @@ describe('Wallet', function() {
 
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, lockup);
@@ -3108,7 +3108,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, 2 * lockup);
@@ -3136,7 +3136,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 4);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, 2 * lockup);
@@ -3152,7 +3152,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 5);
-      assert.strictEqual(bal.coin, 4);
+      assert.strictEqual(bal.coin, 5);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, lockup + value);
@@ -3179,7 +3179,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 5);
-      assert.strictEqual(bal.coin, 4);
+      assert.strictEqual(bal.coin, 5);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, lockup + value);
@@ -3210,7 +3210,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 6);
-      assert.strictEqual(bal.coin, 5);
+      assert.strictEqual(bal.coin, 6);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, value + secondHighest);
@@ -3228,7 +3228,7 @@ describe('Wallet', function() {
       assert.strictEqual(bal.tx, 7);
       // Wallet coin count doesn't change:
       // REVEAL + fee money -> REDEEM + change
-      assert.strictEqual(bal.coin, 5);
+      assert.strictEqual(bal.coin, 6);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, value);
@@ -3246,7 +3246,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 7);
-      assert.strictEqual(bal.coin, 5);
+      assert.strictEqual(bal.coin, 6);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, value);
@@ -3265,7 +3265,7 @@ describe('Wallet', function() {
       assert.strictEqual(bal.tx, 8);
       // Wallet coin count doesn't change:
       // REVEAL + fee money -> REGISTER + change
-      assert.strictEqual(bal.coin, 5);
+      assert.strictEqual(bal.coin, 6);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, secondHighest);
@@ -3283,7 +3283,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 8);
-      assert.strictEqual(bal.coin, 5);
+      assert.strictEqual(bal.coin, 6);
       assert.strictEqual(bal.confirmed, fund - cTXCount * fee);
       assert.strictEqual(bal.unconfirmed, fund - uTXCount * fee);
       assert.strictEqual(bal.ulocked, secondHighest);


### PR DESCRIPTION
This PR reverts null-open test changes and reduces number of unit tests failing at the moment

Signed-off-by: rozaydin <ridvan@namebase.io>