### PR TITLE
Ridvan pending tx by age

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -853,18 +853,6 @@ class HTTP extends Server {
       res.json(200, result);
     });
 
-    //
-    this.get('/wallet/:id/pending', async (req, res) => {
-      const valid = Validator.fromRequest(req);
-      const acct = valid.str('account');
-      const age = valid.u32('age');
-
-      enforce(age, 'Age is required.');
-
-      const txHashes = await req.wallet.getPendingTxHashes(acct, age);
-      res.json(200, txHashes);
-    });
-
     // Wallet TXs within time range
     this.get('/wallet/:id/tx/range', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -853,6 +853,18 @@ class HTTP extends Server {
       res.json(200, result);
     });
 
+    //
+    this.get('/wallet/:id/pending', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const acct = valid.str('account');
+      const age = valid.u32('age');
+
+      enforce(age, 'Age is required.');
+
+      const txHashes = await req.wallet.getPendingTxHashes(acct, age);
+      res.json(200, txHashes);
+    });
+
     // Wallet TXs within time range
     this.get('/wallet/:id/tx/range', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2791,7 +2791,7 @@ class TXDB {
       const tx = await this.getTX(hash);
       assert(tx);
       if (now - tx.mtime >= age) {
-        hashes.push(tx.hash);
+        hashes.push(hash.toString('hex'));
       }
     }
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2791,7 +2791,7 @@ class TXDB {
       const tx = await this.getTX(hash);
       assert(tx);
       if (now - tx.mtime >= age) {
-        hashes.push(hash);
+        hashes.push(tx.hash);
       }
     }
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2773,6 +2773,32 @@ class TXDB {
   }
 
   /**
+   * GetPendingTxs retrieves pending tx hashes older than `age`
+   * @param {Number} acct
+   * @param {Number} age - Age delta.
+   * @returns {Promise<[String]>}
+   */
+
+  async getPendingTxHashes(acct, age) {
+    assert((age >>> 0) === age);
+
+    const now = util.now();
+    const pendingTxs = await this.getPendingHashes(acct);
+
+    const hashes = [];
+
+    for (const hash of pendingTxs) {
+      const tx = await this.getTX(hash);
+      assert(tx);
+      if (now - tx.mtime >= age) {
+        hashes.push(hash);
+      }
+    }
+
+    return hashes;
+  }
+
+  /**
    * Get coins.
    * @param {Number} acct
    * @returns {Promise<Credit[]>} - Returns {@link Credit}[].

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2776,7 +2776,7 @@ class TXDB {
    * GetPendingTxs retrieves pending tx hashes older than `age`
    * @param {Number} acct
    * @param {Number} age - Age delta.
-   * @returns {Promise<[String]>}
+   * @returns {Promise<[Buffer]>}
    */
 
   async getPendingTxHashes(acct, age) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -5170,6 +5170,18 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Get all pending/unconfirmed transactions.
+   * @param {(String|Number)?} acct
+   * @param {Number} age
+   * @returns {Promise<[String]>} - Returns {@link TX}[].
+   */
+
+  async getPendingTxHashes(acct, age) {
+    const account = await this.ensureIndex(acct);
+    return this.txdb.getPendingTxHashes(account, age);
+  }
+
+  /**
    * Get wallet balance.
    * @param {(String|Number)?} acct
    * @returns {Promise} - Returns {@link Balance}.


### PR DESCRIPTION
Adds a new method to txdb to retrieve pending txes by age, and propagates this information to wallet. This new method used by namebase-plugin.

Reading records from DB does not acquire a lock, for the following reason, when deleting the tx using abandon call, abandon call acquiires a lock and checks if tx is eligible for removal or not.