### PR TITLE
wallet: tmp fix for rescan/sync.

### DIFF
--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -1513,7 +1513,7 @@ class ChainDB {
         entry.hash, entry.height);
 
       for (const tx of block.txs) {
-        if (tx.test(filter))
+        // if (tx.test(filter))
           txs.push(tx);
       }
 

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -15,6 +15,8 @@ const Script = require('../script/script');
 const WalletKey = require('./walletkey');
 const { HDPublicKey } = require('../hd/hd');
 
+const PATCHED_LOOKAHEAD = 10000;
+
 /**
  * Account
  * Represents a BIP44 Account belonging to a {@link Wallet}.
@@ -51,7 +53,7 @@ class Account extends bio.Struct {
     this.n = 1;
     this.receiveDepth = 0;
     this.changeDepth = 0;
-    this.lookahead = 1000;
+    this.lookahead = PATCHED_LOOKAHEAD;
     this.accountKey = null;
     this.keys = [];
 
@@ -128,12 +130,12 @@ class Account extends bio.Struct {
       this.changeDepth = options.changeDepth;
     }
 
-    if (options.lookahead != null) {
-      assert((options.lookahead >>> 0) === options.lookahead);
-      assert(options.lookahead >= 0);
-      assert(options.lookahead <= Account.MAX_LOOKAHEAD);
-      this.lookahead = options.lookahead;
-    }
+    // if (options.lookahead != null) {
+    //   assert((options.lookahead >>> 0) === options.lookahead);
+    //   assert(options.lookahead >= 0);
+    //   assert(options.lookahead <= Account.MAX_LOOKAHEAD);
+    //   this.lookahead = options.lookahead;
+    // }
 
     if (options.staticAddress === true) {
       // override
@@ -637,6 +639,7 @@ class Account extends bio.Struct {
    */
 
   async setLookahead(b, lookahead) {
+    assert(false, 'Disabled.');
     if (lookahead === this.lookahead)
       return;
 
@@ -860,11 +863,9 @@ class Account extends bio.Struct {
     this.n = br.readU8();
     this.receiveDepth = br.readU32();
     this.changeDepth = br.readU32();
-    this.lookahead = br.readU8();
     // TODO this is a hack till having mbyte lookahead
-    if (this.lookahead === (0xFF & 1000)) {
-      this.lookahead = 1000;
-    }
+    br.readU8();
+    this.lookahead = PATCHED_LOOKAHEAD;
     this.accountKey = readKey(br);
 
     assert(this.type < Account.typesByVal.length);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -5024,16 +5024,17 @@ class Wallet extends EventEmitter {
 
   async _add(tx, block) {
     const details = await this.txdb.add(tx, block);
+    let derived = [];
 
     if (details) {
-      const derived = await this.syncOutputDepth(tx);
+      derived = await this.syncOutputDepth(tx);
       if (derived.length > 0) {
         this.wdb.emit('address', this, derived);
         this.emit('address', derived);
       }
     }
 
-    return details;
+    return {details, derived};
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -80,6 +80,7 @@ class WalletDB extends EventEmitter {
 
     // Address and outpoint filter.
     this.filter = new BloomFilter();
+    this.filterUpdated = false;
 
     this.init();
   }
@@ -2321,6 +2322,13 @@ class WalletDB extends EventEmitter {
         tip.hash, total);
     }
 
+    if (this.filterUpdated && this.state.height > 0) {
+      this.filterUpdated = false;
+
+      await this.rollback(this.state.height - 1);
+      return this._addBlock(entry, txs);
+    }
+
     return total;
   }
 
@@ -2467,12 +2475,16 @@ class WalletDB extends EventEmitter {
 
       assert(wallet);
 
-      if (await wallet.add(tx, block)) {
+      const {derived, details} = await wallet.add(tx, block);
+      if (details) {
         this.logger.info(
           'Added transaction to wallet in WalletDB: %s (%d).',
           wallet.id, wid);
         result = true;
       }
+
+      if (derived.length > 0)
+        this.filterUpdated = true;
     }
 
     if (!result)

--- a/test/wallet-filter-test.js
+++ b/test/wallet-filter-test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const Network = require('../lib/protocol/network');
+
+const network = Network.get('regtest');
+
+const TEST_WALLET_ID = 'testwallet';
+const TEST_RECOVER_ID = 'testrecover';
+
+// TODO: Increase size of lookahead in the account record
+// so we can store bigger numbers than 255.
+// const TEST_LOOKAHEAD = 10;
+
+describe('Wallet update and send filters/rescan', function() {
+  // TODO: Temporary timeout for Patched LOOKAHEAD
+  this.timeout(10000);
+
+  let node, wdb, pwallet, waddr, twallet, taccount, xpub;
+
+  const sendMine = async (txs) => {
+    for (const txInfo of txs)
+      await pwallet.send(txInfo);
+
+    await node.rpc.generateToAddress([1, waddr]);
+  };
+
+  beforeEach(async () => {
+    node = new FullNode({
+      network: network.type,
+      memory: true,
+      plugins: [require('../lib/wallet/plugin')]
+    });
+
+    await node.open();
+    wdb = node.require('walletdb').wdb;
+
+    pwallet = await wdb.get('primary');
+    twallet = await wdb.create({ id: TEST_WALLET_ID });
+
+    taccount = await twallet.getAccount(0);
+    xpub = taccount.accountKey.toBase58(network);
+
+    waddr = (await pwallet.createReceive(0)).getAddress().toString(network);
+    await node.rpc.generateToAddress([10, waddr]);
+  });
+
+  afterEach(async () => {
+    await node.close();
+  });
+
+  // simple case:
+  //  2 TXs with gapped addresses in derivation order.
+  it('should recover lookahead gapped block (deriv order)', async () => {
+    // TODO: add lookahead configuration back.
+    // assert.strictEqual(taccount.lookahead, TEST_LOOKAHEAD);
+
+    // last address wallet is aware of.
+    const lookaheadReceive = taccount.deriveReceive(
+      taccount.receiveDepth + taccount.lookahead - 1
+    );
+
+    // next last address wallet will become aware of after receiving tx to
+    // lookaheadReceive.
+    const nextLookaheadReceive = taccount.deriveReceive(
+      taccount.receiveDepth + (taccount.lookahead * 2) - 1
+    );
+
+    // in derivation order
+    await sendMine([{
+      outputs: [{
+        value: 1e6,
+        address: lookaheadReceive.getAddress().toString(network)
+      }]
+    }, {
+      outputs: [{
+        value: 1e6,
+        address: nextLookaheadReceive.getAddress().toString(network)
+      }]
+    }]);
+
+    const balance = await twallet.getBalance();
+
+    // recover
+    const rwallet = await wdb.create({
+      id: TEST_RECOVER_ID,
+      watchOnly: true,
+      accountKey: xpub
+    });
+
+    await wdb.rescan(0);
+
+    const recBalance = await rwallet.getBalance();
+    assert.strictEqual(recBalance.tx, balance.tx);
+    assert.strictEqual(recBalance.coin, balance.coin);
+    assert.strictEqual(recBalance.unconfirmed, balance.unconfirmed);
+    assert.strictEqual(recBalance.confirmed, balance.confirmed);
+    assert.strictEqual(recBalance.ulocked, balance.ulocked);
+    assert.strictEqual(recBalance.clocked, balance.clocked);
+  });
+
+  it('should recover lookahead gapped block (rev deriv order)', async () => {
+    // TODO: add lookahead configuration back.
+    // assert.strictEqual(taccount.lookahead, TEST_LOOKAHEAD);
+
+    // last address wallet is aware of.
+    const lookaheadReceive = taccount.deriveReceive(
+      taccount.receiveDepth + taccount.lookahead - 1
+    );
+
+    // next last address wallet will become aware of after receiving tx to
+    // lookaheadReceive.
+    const nextLookaheadReceive = taccount.deriveReceive(
+      taccount.receiveDepth + (taccount.lookahead * 2) - 1
+    );
+
+    // in derivation order
+    await sendMine([{
+      outputs: [{
+        value: 1e6,
+        address: nextLookaheadReceive.getAddress().toString(network)
+      }]
+    }, {
+      outputs: [{
+        value: 1e6,
+        address: lookaheadReceive.getAddress().toString(network)
+      }]
+    }]);
+
+    const balance = await twallet.getBalance();
+
+    // recover
+    const rwallet = await wdb.create({
+      id: TEST_RECOVER_ID,
+      watchOnly: true,
+      accountKey: xpub
+    });
+
+    await wdb.rescan(0);
+
+    const recBalance = await rwallet.getBalance();
+    assert.strictEqual(recBalance.tx, balance.tx);
+    assert.strictEqual(recBalance.coin, balance.coin);
+    assert.strictEqual(recBalance.unconfirmed, balance.unconfirmed);
+    assert.strictEqual(recBalance.confirmed, balance.confirmed);
+    assert.strictEqual(recBalance.ulocked, balance.ulocked);
+    assert.strictEqual(recBalance.clocked, balance.clocked);
+  });
+});


### PR DESCRIPTION
This is temprorary and should not be merged. Proper solution will require more work in multiple places.

Test for the sync setup:
  - remove wallet from the fullnode
  - sync full node to the tip
  - mkwallet with proper wallet xpub or master. `./hsw-cli mkwallet ...`
  - rescan from 0 (or from the height where first tx appears) `./hsw-cli rescan 0`