### PR TITLE
wallet: preload all wallets before HTTP server is started.

### DIFF
--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -52,7 +52,8 @@ class WalletNode extends Node {
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv'),
       migrate: this.config.uint('migrate'),
-      checkLookahead: this.config.bool('check-lookahead', false)
+      checkLookahead: this.config.bool('check-lookahead', false),
+      preloadAll: this.config.bool('preload-all', false)
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -54,7 +54,8 @@ class Plugin extends EventEmitter {
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv,
       migrate: this.config.uint('migrate'),
-      checkLookahead: this.config.bool('check-lookahead', false)
+      checkLookahead: this.config.bool('check-lookahead', false),
+      preloadAll: this.config.bool('preload-all', false)
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -210,6 +210,7 @@ class WalletDB extends EventEmitter {
     await this.migrateChange();
 
     await this.checkLookahead();
+    await this.preloadAll();
   }
 
   /**
@@ -302,6 +303,27 @@ class WalletDB extends EventEmitter {
     }
 
     await b.write();
+  }
+
+  /**
+   * Preload/open all wallets on open.
+   * @returns {Promise}
+   */
+
+  async preloadAll() {
+    if (!this.options.preloadAll)
+      return;
+
+    this.logger.info('Preloading all wallets...');
+
+    const wids = await this.db.keys({
+      gte: layout.W.min(),
+      lte: layout.W.max(),
+      parse: key => layout.W.decode(key)[0]
+    });
+
+    for (const wid of wids)
+      await this._get(wid);
   }
 
   /**
@@ -2519,6 +2541,7 @@ class WalletOptions {
     this.wipeNoReally = false;
     this.migrate = null;
     this.checkLookahead = false;
+    this.preloadAll = false;
 
     if (options)
       this.fromOptions(options);
@@ -2606,6 +2629,10 @@ class WalletOptions {
       this.checkLookahead = options.checkLookahead;
     }
 
+    if (options.preloadAll != null) {
+      assert(typeof options.preloadAll === 'boolean');
+      this.preloadAll = options.preloadAll;
+    }
     return this;
   }
 


### PR DESCRIPTION
This makes sure coin cache that takes long to recover, recovers properly before we start responding to the health checks. This is better signal when wallet is back online.

HSD PR: https://github.com/handshake-org/hsd/pull/803