### PR TITLE
account: fix max lookahead checks.

### DIFF
--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -131,7 +131,8 @@ class Account extends bio.Struct {
     if (options.lookahead != null) {
       assert((options.lookahead >>> 0) === options.lookahead);
       assert(options.lookahead >= 0);
-      assert(options.lookahead <= Account.MAX_LOOKAHEAD);
+      assert(options.lookahead <= Account.MAX_LOOKAHEAD
+          || options.lookahead === 1000);
       this.lookahead = options.lookahead;
     }
 
@@ -924,10 +925,11 @@ Account.typesByVal = [
 
 /**
  * Default address lookahead.
+ *  - 232 is special case for 1k.
  * @const {Number}
  */
 
-Account.MAX_LOOKAHEAD = 1001;
+Account.MAX_LOOKAHEAD = 231;
 
 /*
  * Helpers


### PR DESCRIPTION
anything other than 1k or number <= 231 must not be allowed.