### PR TITLE
 wallet: update/register will accept Buffer instead of Resource.

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1326,15 +1326,17 @@ class HTTP extends Server {
 
       const options = TransactionOptions.fromValidator(valid, this.network);
 
+      const rawResource = resource.encode();
+
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
-        const tx = await req.wallet.sendUpdate(name, resource, options);
+        const tx = await req.wallet.sendUpdate(name, rawResource, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
       // TODO: Add create TX with locks for used Coins and/or
       // adds to the pending list.
-      const mtx = await req.wallet.createUpdate(name, resource, options);
+      const mtx = await req.wallet.createUpdate(name, rawResource, options);
 
       if (sign)
         await req.wallet.sign(mtx, options.passphrase);

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2487,7 +2487,8 @@ class RPC extends RPCBase {
   async sendUpdate(args, help) {
     const opts = this._validateUpdate(args, help, 'sendupdate');
     const wallet = this.wallet;
-    const tx = await wallet.sendUpdate(opts.name, opts.resource, {
+    const rawResource = opts.resource.encode();
+    const tx = await wallet.sendUpdate(opts.name, rawResource, {
       account: opts.account
     });
 
@@ -2497,7 +2498,8 @@ class RPC extends RPCBase {
   async createUpdate(args, help) {
     const opts = this._validateUpdate(args, help, 'createupdate');
     const wallet = this.wallet;
-    const mtx = await wallet.createUpdate(opts.name, opts.resource, {
+    const rawResource = opts.resource.encode();
+    const mtx = await wallet.createUpdate(opts.name, rawResource, {
       paths: true,
       account: opts.account
     });
@@ -2813,7 +2815,8 @@ class RPC extends RPCBase {
             'UPDATE action requires 2 arguments: name, data'
           );
           const {name, resource} = this._validateUpdate(action);
-          actions.push({ type: type, args: [name, resource] });
+          const rawResource = resource.encode();
+          actions.push({ type: type, args: [name, rawResource] });
           break;
         }
         case 'RENEW': {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -34,7 +34,6 @@ const MasterKey = require('./masterkey');
 const policy = require('../protocol/policy');
 const consensus = require('../protocol/consensus');
 const rules = require('../covenants/rules');
-const {Resource} = require('../dns/resource');
 const Claim = require('../primitives/claim');
 const reserved = require('../covenants/reserved');
 const {ownership} = require('../covenants/ownership');
@@ -2607,14 +2606,14 @@ class Wallet extends EventEmitter {
    * Make a register MTX.
    * @private
    * @param {String} name
-   * @param {Resource?} resource
+   * @param {Buffer?} rawResource
    * @param {MTX?} [mtx]
    * @returns {Promise<MTX>}
    */
 
-  async _makeRegister(name, resource, mtx) {
+  async _makeRegister(name, rawResource, mtx) {
     assert(typeof name === 'string');
-    assert(!resource || (resource instanceof Resource));
+    assert(!rawResource || Buffer.isBuffer(rawResource));
 
     if (!rules.verifyName(name))
       throw new Error(`Invalid name: ${name}.`);
@@ -2661,18 +2660,11 @@ class Wallet extends EventEmitter {
     output.address = coin.address;
     output.value = ns.value;
 
-    let rawResource = EMPTY;
-
-    if (resource) {
-      const raw = resource.encode();
-
-      if (raw.length > rules.MAX_RESOURCE_SIZE)
+    if (rawResource && rawResource.length > rules.MAX_RESOURCE_SIZE) {
         throw new Error(
-          `Resource size (${raw.length}) exceeds maximum `+
+          `Resource size (${rawResource.length}) exceeds maximum `+
           `(${rules.MAX_RESOURCE_SIZE}) for name: ${name}.`
         );
-
-      rawResource = raw;
     }
 
     const blockHash = await this.wdb.getRenewalBlock();
@@ -2690,15 +2682,15 @@ class Wallet extends EventEmitter {
   /**
    * Make an update MTX.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {(Number|String)?} acct
    * @param {MTX?} [mtx]
    * @returns {Promise<MTX>}
    */
 
-  async makeUpdate(name, resource, acct, mtx) {
+  async makeUpdate(name, rawResource, acct, mtx) {
     assert(typeof name === 'string');
-    assert(resource instanceof Resource);
+    assert(Buffer.isBuffer(rawResource));
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
@@ -2736,7 +2728,7 @@ class Wallet extends EventEmitter {
     const coin = credit.coin;
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
-      return this._makeRegister(name, resource, mtx);
+      return this._makeRegister(name, rawResource, mtx);
 
     if (ns.isExpired(height, network))
       throw new Error(`Name has expired: ${name}.`);
@@ -2755,15 +2747,13 @@ class Wallet extends EventEmitter {
       throw new Error(`Name is not registered: ${name}.`);
     }
 
-    const raw = resource.encode();
-
-    if (raw.length > rules.MAX_RESOURCE_SIZE)
+    if (rawResource.length > rules.MAX_RESOURCE_SIZE)
       throw new Error(`Resource exceeds maximum size: ${name}.`);
 
     const output = new Output();
     output.address = coin.address;
     output.value = coin.value;
-    output.covenant.setUpdate(nameHash, ns.height, raw);
+    output.covenant.setUpdate(nameHash, ns.height, rawResource);
 
     if (!mtx)
       mtx = new MTX();
@@ -2777,14 +2767,14 @@ class Wallet extends EventEmitter {
    * Create and finalize an update
    * MTX without a lock.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {Object} options
    * @returns {Promise<MTX>}
    */
 
-  async _createUpdate(name, resource, options) {
+  async _createUpdate(name, rawResource, options) {
     const acct = options ? options.account : null;
-    const mtx = await this.makeUpdate(name, resource, acct);
+    const mtx = await this.makeUpdate(name, rawResource, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -2811,14 +2801,14 @@ class Wallet extends EventEmitter {
    * Create and send an update
    * MTX without a lock.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {Object} options
    * @returns {Promise<TX>}
    */
 
-  async _sendUpdate(name, resource, options) {
+  async _sendUpdate(name, rawResource, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this._createUpdate(name, resource, options);
+    const mtx = await this._createUpdate(name, rawResource, options);
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2826,15 +2816,15 @@ class Wallet extends EventEmitter {
    * Create and send an update
    * MTX with a lock.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {Object} options
    * @returns {Promise<TX>}
    */
 
-  async sendUpdate(name, resource, options) {
+  async sendUpdate(name, rawResource, options) {
     const unlock = await this.fundLock.lock();
     try {
-      return await this._sendUpdate(name, resource, options);
+      return await this._sendUpdate(name, rawResource, options);
     } finally {
       unlock();
     }
@@ -4003,8 +3993,8 @@ class Wallet extends EventEmitter {
         case 'UPDATE': {
           assert(args.length === 2, 'Bad arguments for UPDATE.');
           const name = args[0];
-          const resource = args[1];
-          await this.makeUpdate(name, resource, acct, mtx);
+          const rawResource = args[1];
+          await this.makeUpdate(name, rawResource, acct, mtx);
           break;
         }
         case 'RENEW': {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2660,7 +2660,10 @@ class Wallet extends EventEmitter {
     output.address = coin.address;
     output.value = ns.value;
 
-    if (rawResource && rawResource.length > rules.MAX_RESOURCE_SIZE) {
+    if (!rawResource)
+      rawResource = EMPTY;
+
+    if (rawResource.length > rules.MAX_RESOURCE_SIZE) {
         throw new Error(
           `Resource size (${rawResource.length}) exceeds maximum `+
           `(${rules.MAX_RESOURCE_SIZE}) for name: ${name}.`

--- a/test/anyone-can-renew-test.js
+++ b/test/anyone-can-renew-test.js
@@ -127,7 +127,7 @@ describe('Anyone-can-renew address', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['This name is ANYONE-CAN-RENEW']}]
     });
-    await alice.sendUpdate(name, resource);
+    await alice.sendUpdate(name, resource.encode());
     await mineBlocks(network.names.treeInterval);
 
     ns = await node.getNameStatus(nameHash);

--- a/test/claim-test.js
+++ b/test/claim-test.js
@@ -167,7 +167,7 @@ describe('Reserved Name Claims', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['#CooperationGood']}]
     });
-    const register = await wallet.sendUpdate('cloudflare', resource);
+    const register = await wallet.sendUpdate('cloudflare', resource.encode());
     check();
     await mineBlocks(1);
     check();

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -113,7 +113,7 @@ describe('Interactive name swap', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['Contact Alice to buy this name!']}]
     });
-    await alice.sendUpdate(name, resource);
+    await alice.sendUpdate(name, resource.encode());
     await mineBlocks(network.names.treeInterval);
   });
 
@@ -292,7 +292,7 @@ describe('Interactive name swap', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['Thanks Alice! --Bob']}]
     });
-    await bob.sendUpdate(name, resource);
+    await bob.sendUpdate(name, resource.encode());
     await mineBlocks(network.names.treeInterval);
     const actual = await node.chain.db.getNameState(nameHash);
     assert.bufferEqual(resource.encode(), actual.data);

--- a/test/mempool-invalidation-test.js
+++ b/test/mempool-invalidation-test.js
@@ -321,7 +321,8 @@ describe('Mempool Invalidation', function() {
 
       assert.strictEqual(await getNameState(name), states.CLOSED);
 
-      await wallet.sendUpdate(name, Resource.fromJSON({ records: [] }));
+      const res = Resource.fromJSON({ records: [] });
+      await wallet.sendUpdate(name, res.encode());
 
       for (let i = 0; i < network.names.renewalWindow - 2; i++)
         await mineBlock(node);

--- a/test/mempool-reorg-test.js
+++ b/test/mempool-reorg-test.js
@@ -41,9 +41,11 @@ describe('Mempool Covenant Reorg', function () {
 
   let counter = 0;
   function makeResource() {
-    return Resource.fromJSON({
+    const res =  Resource.fromJSON({
       records: [{type: 'TXT', txt: [`${counter++}`]}]
     });
+
+    return res.encode();
   }
 
   it('should fund wallet and win name', async () => {

--- a/test/net-spv-test.js
+++ b/test/net-spv-test.js
@@ -122,16 +122,13 @@ describe('SPV', function() {
       await mineBlocks(biddingPeriod);
       await wallet.sendReveal(name);
       await mineBlocks(revealPeriod);
-      await wallet.sendUpdate(
-        name,
-        Resource.fromJSON(
-          {
-            records: [
-              {type: 'NS', ns: 'one.'}
-            ]
-          }
-        )
-      );
+      const res = Resource.fromJSON({
+        records: [
+          {type: 'NS', ns: 'one.'}
+        ]
+      });
+
+      await wallet.sendUpdate(name, res.encode());
       await mineBlocks(treeInterval + SAFE_ROOT);
     });
 
@@ -166,16 +163,13 @@ describe('SPV', function() {
     });
 
     it('should update name data', async () => {
-      await wallet.sendUpdate(
-        name,
-        Resource.fromJSON(
-          {
-            records: [
-              {type: 'NS', ns: 'two.'}
-            ]
-          }
-        )
-      );
+      const res = Resource.fromJSON({
+        records: [
+          {type: 'NS', ns: 'two.'}
+        ]
+      });
+
+      await wallet.sendUpdate(name, res.encode());
       await mineBlocks(treeInterval + SAFE_ROOT);
     });
 

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -5,7 +5,7 @@ const Network = require('../lib/protocol/network');
 const FullNode = require('../lib/node/fullnode');
 const Address = require('../lib/primitives/address');
 const rules = require('../lib/covenants/rules');
-const Resource = require('../lib/dns/resource');
+const {Resource} = require('../lib/dns/resource');
 const WalletClient = require('../lib/client/wallet');
 
 const network = Network.get('regtest');
@@ -129,20 +129,20 @@ describe('Multiple accounts participating in same auction', function() {
   });
 
   describe('UPDATE', function() {
-    const aliceResource = Resource.Resource.fromJSON({
+    const aliceResource = Resource.fromJSON({
       records: [
         {
           type: 'TXT',
           txt: ['ALICE']
         }
-      ]});
-    const bobResource = Resource.Resource.fromJSON({
+      ]}).encode();
+    const bobResource = Resource.fromJSON({
       records: [
         {
           type: 'TXT',
           txt: ['BOB']
         }
-      ]});
+      ]}).encode();
 
     it('should advance auction to REGISTER phase', async () => {
       await mineBlocks(network.names.revealPeriod);

--- a/test/wallet-balance-test.js
+++ b/test/wallet-balance-test.js
@@ -112,7 +112,7 @@ const FINAL_PRICE_2 = 2e5; // less then 1e6/4 (2.5e5)
 // const BLIND_ONLY_3 = BLIND_AMOUNT_3 - BID_AMOUNT_3;
 
 // Empty resource
-const EMPTY_RS = Resource.fromJSON({ records: [] });
+const EMPTY_RS = Resource.fromJSON({ records: [] }).encode();
 
 /*
  * Wallet helpers

--- a/test/wallet-deepclean-test.js
+++ b/test/wallet-deepclean-test.js
@@ -4,7 +4,7 @@ const assert = require('bsert');
 const Network = require('../lib/protocol/network');
 const FullNode = require('../lib/node/fullnode');
 const Address = require('../lib/primitives/address');
-const Resource = require('../lib/dns/resource');
+const {Resource} = require('../lib/dns/resource');
 
 const network = Network.get('regtest');
 
@@ -93,7 +93,7 @@ describe('Wallet Deep Clean', function() {
       await w.sendReveal(name, {account: 0});
       await mineBlocks(network.names.revealPeriod);
 
-      const res = Resource.Resource.fromJSON({
+      const res = Resource.fromJSON({
         records: [
           {
             type: 'TXT',
@@ -102,7 +102,7 @@ describe('Wallet Deep Clean', function() {
         ]
       });
 
-      await w.sendUpdate(name, res, {account: 0});
+      await w.sendUpdate(name, res.encode(), {account: 0});
       await w.sendRedeem(name, {account: 0});
       await mineBlocks(network.names.treeInterval);
     }

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2400,7 +2400,7 @@ describe('Wallet', function() {
       // Advance to close
       wdb.height += network.names.revealPeriod;
 
-      const resource = Resource.fromJSON({records: []});
+      const resource = Resource.fromJSON({records: []}).encode();
       const register = await wallet.sendUpdate(name, resource, {hardFee: fee});
       uTXCount++;
 
@@ -2779,7 +2779,7 @@ describe('Wallet', function() {
       // Advance to close
       wdb.height += network.names.revealPeriod;
 
-      const resource = Resource.fromJSON({records: []});
+      const resource = Resource.fromJSON({records: []}).encode();
       const register = await wallet.createUpdate(name, resource, {hardFee: fee});
 
       // Check
@@ -3174,7 +3174,7 @@ describe('Wallet', function() {
         records: [{type: 'NS', ns: 'ns1.easyhandshake.com.'}]
       });
 
-      update = await wallet.sendUpdate('cloudflare', records);
+      update = await wallet.sendUpdate('cloudflare', records.encode());
       const entry = nextEntry(wdb);
       await wdb.addBlock(entry, [update]);
 
@@ -3558,7 +3558,7 @@ describe('Wallet', function() {
 
     it('should send and confirm REGISTER', async () => {
       const resource = Resource.fromJSON({ records: [] });
-      const register = await wallet.sendUpdate(name, resource, {
+      const register = await wallet.sendUpdate(name, resource.encode(), {
         hardFee: fee
       });
       uTXCount++;


### PR DESCRIPTION
Resource will only be used by the HTTP/RPC endpoints to validate the incoming JSON and they will re-encode to buffer.

This allows for plugins etc to extend update/register behaviour with their custom raw resource validation.
