### PR TITLE
wdb: add min sweep dust configuration.

### DIFF
--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -55,7 +55,8 @@ class WalletNode extends Node {
       icannlockup: this.config.bool('icannlockup', true),
       migrateNoRescan: this.config.bool('migrate-no-rescan', false),
       preloadAll: this.config.bool('preload-all', false),
-      maxHistoryTXs: this.config.uint('max-history-txs', 100)
+      maxHistoryTXs: this.config.uint('max-history-txs', 100),
+      sweepdustMinValue: this.config.uint('sweepdust-min-value', 1)
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -64,7 +64,8 @@ class Plugin extends EventEmitter {
       icannlockup: this.config.bool('icannlockup', true),
       migrateNoRescan: this.config.bool('migrate-no-rescan', false),
       preloadAll: this.config.bool('preload-all', false),
-      maxHistoryTXs: this.config.uint('max-history-txs', 100)
+      maxHistoryTXs: this.config.uint('max-history-txs', 100),
+      sweepdustMinValue: this.config.uint('sweepdust-min-value', 1)
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -120,6 +120,9 @@ class Wallet extends EventEmitter {
     this.maxAncestors = policy.MEMPOOL_MAX_ANCESTORS;
     this.absurdFactor = policy.ABSURD_FEE_FACTOR;
 
+    /** @type {Amount} */
+    this.sweepdustMinValue = wdb.options.sweepdustMinValue || 1;
+
     if (options)
       this.fromOptions(options);
   }
@@ -5812,7 +5815,7 @@ class WalletCoinSource extends AbstractCoinSource {
     this.selection = DEFAULT_SELECTION;
     this.smart = false;
 
-    this.sweepdustMinValue = 1;
+    this.sweepdustMinValue = wallet.sweepdustMinValue;
     this.signal = null;
 
     if (options)

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -37,6 +37,7 @@ const {scanActions} = require('../blockchain/common');
 
 /** @typedef {ReturnType<bdb.DB['batch']>} Batch */
 /** @typedef {import('../types').Hash} Hash */
+/** @typedef {import('../types').Amount} Amount */
 /** @typedef {import('../primitives/tx')} TX */
 /** @typedef {import('../primitives/claim')} Claim */
 /** @typedef {import('../blockchain/common').ScanAction} ScanAction */
@@ -2912,6 +2913,10 @@ class WalletOptions {
     this.preloadAll = false;
     this.maxHistoryTXs = 100;
 
+    // Used in sweepdust filter.
+    /** @type {Amount} */
+    this.sweepdustMinValue = 1;
+
     this.nowFn = util.now;
 
     if (options)
@@ -3019,6 +3024,12 @@ class WalletOptions {
       assert((options.maxHistoryTXs >>> 0) === options.maxHistoryTXs);
       assert(options.maxHistoryTXs > 0);
       this.maxHistoryTXs = options.maxHistoryTXs;
+    }
+
+    if (options.sweepdustMinValue != null) {
+      assert(typeof options.sweepdustMinValue === 'number');
+      assert(options.sweepdustMinValue >= 0);
+      this.sweepdustMinValue = options.sweepdustMinValue;
     }
 
     return this;


### PR DESCRIPTION
Previously default would be 1. Now default can be rewritten for all wallets. HTTP Request can still override this limit.