### PR TITLE
wallet: Return output to action.id mappings.

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3958,13 +3958,16 @@ class Wallet extends EventEmitter {
    * @property {MTX} [mtx] - The resulting transaction
    * @property {BatchError[]} errors - List of errors encountered during
    *  processing.
+   * @property {WeakMap<Output, String>} outputMap - Output id id mappings.
    */
 
   /**
    * @typedef {Object} BatchTXResult
+   * @property {MTX} [mtx] - The resulting transaction
    * @property {TX} [tx] - The resulting transaction
    * @property {BatchError[]} errors - List of errors encountered during
    *  processing.
+   * @property {WeakMap<Output, String>} outputMap - Output to id mappings.
    */
 
   /**
@@ -4021,6 +4024,9 @@ class Wallet extends EventEmitter {
     let receiveIndex = account.receiveDepth - 1;
     /** @type {BatchError[]} */
     const errors = [];
+
+    /** @type {WeakMap<Output, String>} */
+    const outputMap = new WeakMap();
 
     /**
      * @param {BatchAction} action
@@ -4141,7 +4147,15 @@ class Wallet extends EventEmitter {
       assert(Array.isArray(args), 'Action args must be an array.');
 
       try {
+        const lastOutputIndex = mtx.outputs.length;
         await handleAction(action, args);
+
+        if (action.id) {
+          for (let i = lastOutputIndex; i < mtx.outputs.length; i++) {
+            const output = mtx.outputs[i];
+            outputMap.set(output, action.id);
+          }
+        }
       } catch (err) {
         if (!options.partialFailure)
           throw err;
@@ -4173,7 +4187,8 @@ class Wallet extends EventEmitter {
 
       return {
         mtx: null,
-        errors
+        errors,
+        outputMap
       };
     }
 
@@ -4214,7 +4229,7 @@ class Wallet extends EventEmitter {
         throw new Error('Batch output addresses would exceed lookahead.');
     }
 
-    return {mtx, errors};
+    return {mtx, errors, outputMap};
   }
 
   /**
@@ -4225,15 +4240,16 @@ class Wallet extends EventEmitter {
    */
 
   async _createBatch(actions, options) {
-    const {mtx, errors} = await this.makeBatch(actions, options);
+    const {mtx, errors, outputMap} = await this.makeBatch(actions, options);
 
     if (!mtx)
-      return { mtx: null, errors };
+      return { mtx: null, errors, outputMap };
 
     await this.fill(mtx, options);
     return {
       mtx: await this.finalize(mtx, options),
-      errors
+      errors,
+      outputMap
     };
   }
 
@@ -4262,13 +4278,15 @@ class Wallet extends EventEmitter {
 
   async _sendBatch(actions, options) {
     const passphrase = options ? options.passphrase : null;
-    const {mtx, errors} = await this._createBatch(actions, options);
+    const {mtx, errors, outputMap} = await this._createBatch(actions, options);
 
     checkSendAbort(options);
 
     return {
+      mtx,
       tx: mtx ? await this.sendMTX(mtx, passphrase) : null,
-      errors
+      errors,
+      outputMap
     };
   }
 


### PR DESCRIPTION
Bids need a way to map outputs to action.ids. Unfortunately, output information can't be processed in a way that allows this easily. Theoretically it's possible to use blind value + name, sort them OR use blind to do db lookup for blinds, but this makes it straightforward to check on mtx outputs.