### PR TITLE
Nb batch limits

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -4147,11 +4147,34 @@ class Wallet extends EventEmitter {
       assert(Array.isArray(args), 'Action args must be an array.');
 
       try {
-        const lastOutputIndex = mtx.outputs.length;
+        const lastOutputsLen = mtx.outputs.length;
+        const lastInputsLen = mtx.inputs.length;
         await handleAction(action, args);
 
+        const opens = rules.countOpens(mtx);
+        const updates = rules.countUpdates(mtx);
+        const renewals = rules.countRenewals(mtx);
+
+        if (opens > consensus.MAX_BLOCK_OPENS) {
+          mtx.inputs.length = lastInputsLen;
+          mtx.outputs.length = lastOutputsLen;
+          throw new Error('Too many OPENs.');
+        }
+
+        if (updates > consensus.MAX_BLOCK_UPDATES) {
+          mtx.inputs.length = lastInputsLen;
+          mtx.outputs.length = lastOutputsLen;
+          throw new Error('Too many UPDATEs.');
+        }
+
+        if (renewals > consensus.MAX_BLOCK_RENEWALS) {
+          mtx.inputs.length = lastInputsLen;
+          mtx.outputs.length = lastOutputsLen;
+          throw new Error('Too many RENEWs.');
+        }
+
         if (action.id) {
-          for (let i = lastOutputIndex; i < mtx.outputs.length; i++) {
+          for (let i = lastOutputsLen; i < mtx.outputs.length; i++) {
             const output = mtx.outputs[i];
             outputMap.set(output, action.id);
           }
@@ -4170,15 +4193,6 @@ class Wallet extends EventEmitter {
           id: action.id || null
         });
       }
-
-      if (rules.countOpens(mtx) > consensus.MAX_BLOCK_OPENS)
-        throw new Error('Too many OPENs.');
-
-      if (rules.countUpdates(mtx) > consensus.MAX_BLOCK_UPDATES)
-        throw new Error('Too many UPDATEs.');
-
-      if (rules.countRenewals(mtx) > consensus.MAX_BLOCK_RENEWALS)
-        throw new Error('Too many RENEWs.');
     }
 
     if (!mtx.outputs.length) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3976,6 +3976,8 @@ class Wallet extends EventEmitter {
    * @param {Object} options
    * @param {Number|String} [options.account=0] - Account index or name.
    * @param {Boolean} [options.partialFailure=false] - Allow partial failure.
+   * @param {Number} [options.maxOutputs=0] - Max limit of the outputs.
+   *   NOTE: It will be +1 with change address.
    * @throws {Error} - general validations.
    * @returns {Promise<BatchResult>}
    */
@@ -3983,8 +3985,11 @@ class Wallet extends EventEmitter {
   async makeBatch(actions, options = {}) {
     assert(Array.isArray(actions));
     assert(actions.length, 'Batches require at least one action.');
+    assert(options);
+    assert(!options.maxOutputs || options.maxOutputs > 0,
+      'maxOutputs must be non-negative.');
 
-    const acct = options ? options.account || 0 : 0;
+    const acct = options.account || 0;
     const mtx = new MTX();
 
     // Track estimated size of batch TX to keep it under policy limit
@@ -4171,6 +4176,12 @@ class Wallet extends EventEmitter {
           mtx.inputs.length = lastInputsLen;
           mtx.outputs.length = lastOutputsLen;
           throw new Error('Too many RENEWs.');
+        }
+
+        if (options.maxOutputs && mtx.outputs.length > options.maxOutputs) {
+          mtx.inputs.length = lastInputsLen;
+          mtx.outputs.length = lastOutputsLen;
+          throw new Error(`Too many outputs, limit: ${options.maxOutputs}.`);
         }
 
         if (action.id) {


### PR DESCRIPTION
 - Instead of failing the whole transaction fail the actions that exceed the limits.
 - Add maxOutputs option to have soft limit controlled via makeBatch api.