### PR TITLE
wallet: use sweepdust min value configuration for db-value selection

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -6024,6 +6024,7 @@ class WalletCoinSource extends AbstractCoinSource {
       case common.coinSelectionTypes.DB_VALUE:
       case common.coinSelectionTypes.DB_ALL: {
         this.iter = this.txdb.getAccountCreditIterByValue(this.account, {
+          minValue: this.sweepdustMinValue,
           reverse: true
         });
         break;


### PR DESCRIPTION
Sweepdust min value will now also affect db-value coin selection. There's no point counting below that if sweepdust would not get rid of them either. 